### PR TITLE
Basic 신진호 sprint3

### DIFF
--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -1,0 +1,6 @@
+<component name="InspectionProjectProfileManager">
+  <profile version="1.0">
+    <option name="myName" value="Project Default" />
+    <inspection_tool class="BadExpressionStatementJS" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
+  </profile>
+</component>

--- a/.idea/material_theme_project_new.xml
+++ b/.idea/material_theme_project_new.xml
@@ -3,8 +3,15 @@
   <component name="MaterialThemeProjectNewConfig">
     <option name="metadata">
       <MTProjectMetadataState>
-        <option name="userId" value="-57eb8090:193ee619227:-7ffd" />
+        <option name="migrated" value="true" />
+        <option name="pristineConfig" value="false" />
+        <option name="userId" value="2fe22129:193ec6a8941:-7ff9" />
       </MTProjectMetadataState>
+    </option>
+    <option name="titleBarState">
+      <MTProjectTitleBarConfigState>
+        <option name="overrideColor" value="false" />
+      </MTProjectTitleBarConfigState>
     </option>
   </component>
 </project>

--- a/.idea/material_theme_project_new.xml
+++ b/.idea/material_theme_project_new.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="MaterialThemeProjectNewConfig">
+    <option name="metadata">
+      <MTProjectMetadataState>
+        <option name="userId" value="-57eb8090:193ee619227:-7ffd" />
+      </MTProjectMetadataState>
+    </option>
+  </component>
+</project>

--- a/index.html
+++ b/index.html
@@ -43,8 +43,7 @@
       <section id="hero" class="banner">
         <div class="wrapper">
           <h1>
-            일상의 모든 물건을<br />
-            거래해 보세요
+            일상의 모든 물건을 거래해 보세요
           </h1>
           <a href="items.html" class="button pill-button">구경하러 가기</a>
         </div>
@@ -59,7 +58,7 @@
           />
           <div class="feature-content">
             <h2 class="feature-tag">Hot item</h2>
-            <h1>인기 상품을<br />확인해 보세요</h1>
+            <h1>인기 상품을 확인해 보세요</h1>
             <p class="feature-description">
               가장 HOT한 중고거래 물품을<br />판다마켓에서 확인해 보세요
             </p>
@@ -68,7 +67,7 @@
         <div class="feature">
           <div class="feature-content">
             <h2 class="feature-tag">Search</h2>
-            <h1>구매를 원하는<br />상품을 검색하세요</h1>
+            <h1>구매를 원하는 상품을 검색하세요</h1>
             <p class="feature-description">
               구매하고 싶은 물품은 검색해서
               <br />쉽게 찾아보세요
@@ -88,7 +87,7 @@
           />
           <div class="feature-content">
             <h2 class="feature-tag">Register</h2>
-            <h1>판매를 원하는<br />상품을 등록하세요</h1>
+            <h1>판매를 원하는 상품을 등록하세요</h1>
             <p class="feature-description">
               어떤 물건이든 판매하고 싶은 상품을
               <br />쉽게 등록하세요
@@ -109,7 +108,7 @@
     </main>
 
     <footer>
-      <div>©codeit - 2024</div>
+      <div class="copyright">©codeit - 2024</div>
       <div id="footerMenu">
         <a href="privacy.html">Privacy Policy</a>
         <a href="faq.html">FAQ</a>

--- a/index.html
+++ b/index.html
@@ -11,8 +11,8 @@
       crossorigin
       href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/static/pretendard.min.css"
     />
-    <link rel="stylesheet" href="styles/global.css" />
-    <link rel="stylesheet" href="styles/home.css" />
+    <link rel="stylesheet" href="/styles/global.css" />
+    <link rel="stylesheet" href="/styles/home.css" />
 
     <!-- [심화 요구사항] Google Analytics  -->
     <!-- Google Analytics 계정을 생성해 ) 본인의 Tracking ID(예: G-XXXXXXXXXX)로 변경이 필요합니다. -->

--- a/index.html
+++ b/index.html
@@ -14,21 +14,6 @@
     <link rel="stylesheet" href="/styles/global.css" />
     <link rel="stylesheet" href="/styles/home.css" />
 
-    <!-- [심화 요구사항] Google Analytics  -->
-    <!-- Google Analytics 계정을 생성해 ) 본인의 Tracking ID(예: G-XXXXXXXXXX)로 변경이 필요합니다. -->
-    <script
-      async
-      src="https://www.googletagmanager.com/gtag/js?id=G-본인의_Tracking_ID"
-    ></script>
-    <script>
-      window.dataLayer = window.dataLayer || [];
-      function gtag() {
-        dataLayer.push(arguments);
-      }
-      gtag("js", new Date());
-
-      gtag("config", "G-XXXXXXXXXX"); // 본인의 Tracking ID로 변경
-    </script>
   </head>
 
   <body>

--- a/items.html
+++ b/items.html
@@ -23,7 +23,7 @@
       crossorigin
       href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/static/pretendard.min.css"
     />
-    <link rel="stylesheet" href="styles/global.css" />
+    <link rel="stylesheet" href="/styles/global.css" />
   </head>
 
   <body>

--- a/login.html
+++ b/login.html
@@ -17,43 +17,6 @@
         /></a>
       </div>
 
-      <!-- 
-        <form 태그>
-        - 사용자에게 정보를 입력 받을 때는 HTML의 <form> 태그를 사용하는 것이 좋아요. 
-        - method 속성으로 form 데이터의 전송 방식을 선택해줄 수 있어요.
-          1. `get`: 속성값을 별도로 명시해주지 않으면 기본 설정인 get이 사용됩니다. 입력 데이터가 URL에 포함되어 전송되므로, 주로 검색어와 같이 공개적으로 노출되어도 문제가 없는 데이터를 전송할 때 사용합니다.
-          2. `post`: 보안이 중요한 개인정보 입력 양식에서는 반드시 post를 사용해야 해요. 사진 업로드 처럼 데이터 크기가 큰 경우에도 post를 사용합니다.
-        - 동일 페이지 내에 form이 여러 개 있을 경우 구별을 위해 선택적으로 name 속성을 추가해 주기도 합니다.
-      -->
-
-      <!-- 
-        <input & label의 연결>
-        - 입력 필드의 명칭을 표시할 때는 div나 일반 텍스트 요소보다는 <label> 태그를 사용하는 것이 좋습니다.
-        - <label>의 for 속성과 <input>의 id 속성에 같은 값을 넣어주면 하나의 짝으로 인식돼요.
-        - 시각장애인들이 사용하는 스크린 리더와 같은 보조 기술은 <label>을 통해 <input> 필드의 목적을 사용자에게 알려주기 때문에 웹 접근성(accessibility) 측면에서도 중요합니다.
-        - <label> 내부에 <input>을 nest 하는 암묵적(implicit) 연결 방식을 사용한다면 for와 id 속성 없이도 자동으로 레이블과 입력 필드가 연결됩니다. 
-          하지만 일부 스크린 리더에서는 이런 구조를 정확하게 인식하지 못하는 것으로 알려져 있어, 아직까지는 다양한 사용자와 환경을 고려해 항상 for와 id 속성을 명시하는 것을 권장합니다.
-
-        <input 속성: name>
-        - name 속성은 폼이 서버로 전송될 때, 서버가 각 입력 필드의 데이터를 식별하는 데 사용하는 식별자입니다.
-        - <input>에 name 속성이 없으면 서버에 해당 필드의 입력값이 전송되지 않으니 잊지 않고 name 속성을 지정해 주세요.
-        - name 속성은 라디오 버튼과 같이 여러 선택지 중 하나만 선택할 수 있는 입력 필드에서 중요한 역할을 하기도 해요.
-          동일한 name 값을 가진 <input> 태그들은 하나의 그룹으로 묶이며, 그 중 사용자가 선택한 옵션의 값만이 서버로 전송됩니다.
-          (예: 성별 선택)
-              <input type="radio" id="male" name="gender" value="male">
-              <label for="male">남</label>
-              <input type="radio" id="female" name="gender" value="female">
-              <label for="female">여</label>
-
-        <input 속성: type>
-        - <input>의 type 속성을 적절히 활용하면 HTML이 제공하는 다양한 입력 필드 기능을 상황에 맞게 사용할 수 있어요. 
-        - 예: <input> type을 `email`로 설정하면 사용자가 입력한 값이 이메일 형식에 맞는지 기본적인 유효성 검증을 하기에 용이합니다. 이 기능은 추후에 더 다뤄볼게요.
-        - 예: <input> type을 `password`로 설정하면 입력 내용이 마스킹 처리 돼요.
-
-        <input 속성: placeholder>
-        - 입력 창에 입력값이 없을 때 표시할 내용입니다. 안내사항 또는 예상 입력 형식 힌트를 제공하는 용도로 활용됩니다.
-      -->
-
       <form method="post">
         <div class="input-item">
           <label for="email">이메일</label>
@@ -63,8 +26,7 @@
             type="email"
             placeholder="이메일을 입력해 주세요"
           />
-          <p class="emailEmpty">이메일을 입력해주세요.</p>
-          <p class="emailWrong">잘못된 이메일 형식입니다.</p>
+          <p id="emailError">잘못된 이메일 형식입니다.</p>
         </div>
         <div class="input-item">
           <label for="password">비밀번호</label>
@@ -75,17 +37,6 @@
               type="password"
               placeholder="비밀번호를 입력해 주세요"
             />
-            <!-- 
-              <button> type 속성의 중요성
-              - <form> 내에 있는 <button>은 type 속성을 명시하지 않으면 기본적으로 type="submit"으로 적용됩니다. 
-              - 비밀번호 토글 버튼을 클릭했을 때 페이지가 새로고침되는 현상이 있었다면 아마 이 이슈였을 거예요.
-              - 원치 않을 때 폼이 제출되는 것을 막기 위해, 제출 버튼이 아니라면 type="button"을 꼭 추가해 주세요!
-            -->
-            <!-- 
-              - aria-label은 웹 요소의 목적이나 내용을 스크린 리더와 같은 보조 기술 사용자에게 명확하게 설명하기 위해 사용되는 접근성 속성이에요.
-              - 웹 접근성을 고려해 아이콘으로만 된 버튼 또는 링크처럼 텍스트 정보가 없는 요소에는 aria-label을 추가해 주는 것을 추천해요.
-            -->
-            <!-- [심화 요구사항] 비밀번호, 비밀번호 확인 input 요소 오른쪽에 비밀번호를 확인할 수 있는 눈 모양 아이콘을 추가합니다. -->
             <button
               type="button"
               class="password-toggle-button"
@@ -97,11 +48,10 @@
               />
             </button>
           </div>
-          <p class="pwEmpty">비밀번호를 입력해주세요.</p>
-          <p class="pwWrong">비밀번호를 8자 이상 입력해주세요.</p>
+          <p id="passwordError">비밀번호를 입력해주세요.</p>
         </div>
 
-        <button type="button" class="button pill-button full-width">
+        <button type="button" class="login-button button pill-button full-width" disabled>
           로그인
         </button>
       </form>
@@ -137,7 +87,7 @@
       </div>
     </main>
 
-    <div class="popUp-wrapper">
+    <div class="popup-wrapper">
       <div class="popUp">
         <p>비밀번호가 일치하지 않습니다.</p>
         <button class="modal-button">확인</button>

--- a/login.html
+++ b/login.html
@@ -138,5 +138,6 @@
         판다마켓이 처음이신가요? <a href="signup.html">회원가입</a>
       </div>
     </main>
+    <script src="scripts/login.js"></script>
   </body>
 </html>

--- a/login.html
+++ b/login.html
@@ -69,6 +69,8 @@
             type="email"
             placeholder="이메일을 입력해 주세요"
           />
+          <p class="emailEmpty">이메일을 입력해주세요.</p>
+          <p class="emailWrong">잘못된 이메일 형식입니다.</p>
         </div>
         <div class="input-item">
           <label for="password">비밀번호</label>
@@ -101,9 +103,11 @@
               />
             </button>
           </div>
+          <p class="pwEmpty">비밀번호를 입력해주세요.</p>
+          <p class="pwWrong">비밀번호를 8자 이상 입력해주세요.</p>
         </div>
 
-        <button type="submit" class="button pill-button full-width">
+        <button type="button" class="button pill-button full-width">
           로그인
         </button>
       </form>

--- a/login.html
+++ b/login.html
@@ -4,15 +4,9 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>판다마켓 - 로그인</title>
-    <link rel="icon" href="images/logo/favicon.ico" />
-    <link
-      rel="stylesheet"
-      as="style"
-      crossorigin
-      href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/static/pretendard.min.css"
-    />
-    <link rel="stylesheet" href="styles/global.css" />
-    <link rel="stylesheet" href="styles/auth.css" />
+    <link rel="stylesheet" as="style" crossorigin href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/static/pretendard.min.css" />
+    <link rel="stylesheet" href="/styles/global.css" />
+    <link rel="stylesheet" href="/styles/auth.css" />
   </head>
 
   <body>
@@ -142,6 +136,13 @@
         판다마켓이 처음이신가요? <a href="signup.html">회원가입</a>
       </div>
     </main>
+
+    <div class="popUp-wrapper">
+      <div class="popUp">
+        <p>비밀번호가 일치하지 않습니다.</p>
+        <button class="modal-button">확인</button>
+      </div>
+    </div>
     <script src="scripts/login.js"></script>
   </body>
 </html>

--- a/login.html
+++ b/login.html
@@ -87,7 +87,7 @@
       </div>
     </main>
 
-    <div class="popup-wrapper">
+    <div class="errorModal">
       <div class="popUp">
         <p>비밀번호가 일치하지 않습니다.</p>
         <button class="modal-button">확인</button>

--- a/scripts/login.js
+++ b/scripts/login.js
@@ -1,27 +1,39 @@
+// 미션 제출 시간이 얼마 남지 않아 아쉽게도 말씀해주신 부분에 대해 구현하지 못했지만
+// 1. 순수한 함수를 작성한다는 것의 의미를 생각해봤습니다.
+// 외부 데이터의 영향을 주고 받지 않으며 정해진 작업을 수행할 수 있는
+// 아무데나 끼워도 맞춰지는 레고 블럭 같은 것이 순수 함수인 것이 아닐까 생각됩니다.
+//
+// 2. some 함수는 return 값이 true / false 두 개였습니다!
+// ForEach는 일치 값이 나오더라도 모든 데이터를 확인하는 반면, some은 일치 값이 나오면 true를 리턴하고 반복을 종료합니다.
+//
+// 3. 스타일을 바로 조작하지 않고 클래스를 만들어 a.className = (".turnOnBorderAlert"); 와 같이 사용할 수 있을 것 같습니다.
+// ^^7 충성
+
+
 const USER_DATA = [
-    { email: 'codeit1@codeit.com', password: "codeit101!" },
-    { email: 'codeit2@codeit.com', password: "codeit202!" },
-    { email: 'codeit3@codeit.com', password: "codeit303!" },
-    { email: 'codeit4@codeit.com', password: "codeit404!" },
-    { email: 'codeit5@codeit.com', password: "codeit505!" },
-    { email: 'codeit6@codeit.com', password: "codeit606!" },
+  {email: 'codeit1@codeit.com', password: "codeit101!"},
+  {email: 'codeit2@codeit.com', password: "codeit202!"},
+  {email: 'codeit3@codeit.com', password: "codeit303!"},
+  {email: 'codeit4@codeit.com', password: "codeit404!"},
+  {email: 'codeit5@codeit.com', password: "codeit505!"},
+  {email: 'codeit6@codeit.com', password: "codeit606!"},
 ]
 
 const loginBtn = document.querySelector('.login-button');
 const toggleBtn = document.querySelector('.password-toggle-button');
-const popUp = document.querySelector('.popup-wrapper');
+const popUp = document.querySelector('.errorModal');
 const popupCloseBtn = document.querySelector('.modal-button');
 const email = {
-    input: document.querySelector('#email'),
-    error: document.querySelector('#emailError'),
-    empty: "이메일을 입력해주세요.",
-    wrong: "유효한 이메일 형식이 아닙니다.",
+  input: document.querySelector('#email'),
+  error: document.querySelector('#emailError'),
+  empty: "이메일을 입력해주세요.",
+  wrong: "유효한 이메일 형식이 아닙니다.",
 }
 const password = {
-    input: document.querySelector('#password'),
-    error: document.querySelector('#passwordError'),
-    empty: "비밀번호를 입력해주세요",
-    wrong: "비밀번호를 8자 이상 입력해주세요",
+  input: document.querySelector('#password'),
+  error: document.querySelector('#passwordError'),
+  empty: "비밀번호를 입력해주세요",
+  wrong: "비밀번호를 8자 이상 입력해주세요",
 }
 
 // 이메일, 패스워드 정상 입력 받았는지 확인용 변수
@@ -30,74 +42,81 @@ let passwordValidation = false;
 
 // 이메일 검증
 email.input.addEventListener('focusout', e => {
-    const inputValue = e.target.value;
+  const inputValue = e.target.value;
 
-    if(!inputValue) showMessage(email, email.empty);
-    else if(!emailValidCheck(inputValue)) showMessage(email, email.wrong);
-    else {
-        clearMessage(email);
-        emailValidation = true;
-        canEnableButton()
-    }
+  if (!inputValue) showMessage(email, email.empty);
+  else if (!emailValidCheck(inputValue)) showMessage(email, email.wrong);
+  else {
+    clearMessage(email);
+    emailValidation = true;
+    canEnableButton()
+  }
 })
 // 비밀번호 검증
 password.input.addEventListener('focusout', e => {
-    const inputValue = e.target.value;
+  const inputValue = e.target.value;
 
-    if (!inputValue) showMessage(password, password.empty);
-    else if (!isOverEight(inputValue)) showMessage(password, password.wrong);
-    else {
-        clearMessage(password);
-        passwordValidation = true;
-        canEnableButton()
-    }
+  if (!inputValue) showMessage(password, password.empty);
+  else if (!isOverEight(inputValue)) showMessage(password, password.wrong);
+  else {
+    clearMessage(password);
+    passwordValidation = true;
+    canEnableButton()
+  }
 })
 // 비밀번호 눈 아이콘 구현
 toggleBtn.addEventListener('click', e => {
-    toggleEyeButton();
+  toggleEyeButton();
 })
 // 로그인 버튼을 눌렀을 때, 입력된 데이터가 USER_DATA의 정보와 일치하는 경우 items 페이지로 이동, 그렇지 않은 경우 팝업
 loginBtn.addEventListener('click', e => {
-    USER_DATA.some((user) => {
-        const emailValid = (user.email === email.input.value);
-        const passwordValid = (user.password === password.input.value);
+  const validLoginInput = USER_DATA.some((user) => {
+    return (user.email === email.input.value && user.password === password.input.value);
+  })
 
-        if(emailValid && passwordValid) window.location.href = "../items.html";
-        else popUp.style.display = "block";
-    })
+    if (validLoginInput) window.location.href = "../items.html";
+    else popUp.style.display = "block";
 })
 // 팝업 확인 버튼
 popupCloseBtn.addEventListener('click', e => {
-    popUp.style.display = "none";
+  popUp.style.display = "none";
 })
 
 
 //////////////// functions /////////////////////
 function showMessage(target, message) {
-    target.error.style.display = "block";
-    target.error.innerHTML = message;
-    target.input.style.border = "2px solid #F74747";
-    target.input.style.outlineColor = "#F74747";
+  target.error.style.display = "block";
+  target.error.innerHTML = message;
+  target.input.style.border = "2px solid #F74747";
+  target.input.style.outlineColor = "#F74747";
 }
-function clearMessage(target) {
-    target.error.style.display = "none";
-    target.error.innerHTML = "";
-    target.input.style.border = "";
-    target.input.style.outlineColor = "";
-}
-function emailValidCheck(value) {
-    const pattern = /^[A-Za-z0-9_\.\-]+@[A-Za-z0-9\-]+\.[A-za-z0-9\-]+/;
 
-    if(pattern.test(value) === false) { return false; }
-    else { return true; }
+function clearMessage(target) {
+  target.error.style.display = "none";
+  target.error.innerHTML = "";
+  target.input.style.border = "";
+  target.input.style.outlineColor = "";
 }
+
+function emailValidCheck(value) {
+  const pattern = /^[A-Za-z0-9_\.\-]+@[A-Za-z0-9\-]+\.[A-za-z0-9\-]+/;
+
+  if (pattern.test(value) === false) {
+    return false;
+  } else {
+    return true;
+  }
+}
+
 function isOverEight(value) {
-    return (value.length >= 8);
+  return (value.length >= 8);
 }
+
 function toggleEyeButton() {
-    if (password.input.type === "password") password.input.type = "text";
-    else password.input.type = "password";
+  if (password.input.type === "password") password.input.type = "text";
+  else password.input.type = "password";
 }
+
 function canEnableButton() {
-    loginBtn.disabled = !(emailValidation && passwordValidation);
+  loginBtn.disabled = !(emailValidation && passwordValidation);
 }

--- a/scripts/login.js
+++ b/scripts/login.js
@@ -16,14 +16,12 @@ const pwEmpty = document.querySelector('.pwEmpty');
 const loginBtn = document.querySelector('.button');
 const toggleBtn = document.querySelector('.password-toggle-button');
 
-
 // 이메일, 패스워드 정상 입력 받았는지 확인용 변수
 let checkEmail = false;
 let checkPw = false;
 
 // 로그인 버튼 비활성화
 loginBtn.disabled = true;
-
 // 이메일 비어있는지 확인 후 @ 포함됐는지 검증
 email.addEventListener('input', e => {
 
@@ -47,7 +45,6 @@ email.addEventListener('input', e => {
         activateLoginBtn()
     }
 })
-
 // 패스워드 비어있는지 확인 후 8자 이상인지 검증
 password.addEventListener('input', e => {
 
@@ -72,7 +69,6 @@ password.addEventListener('input', e => {
         activateLoginBtn()
     }
 })
-
 // 비밀번호 눈 아이콘 구현
 toggleBtn.addEventListener('click', e => {
     if(password.type === "password"){
@@ -81,7 +77,6 @@ toggleBtn.addEventListener('click', e => {
         password.type = "password";
     }
 })
-
 // 이메일과 패스워드가 모두 정상적으로 입력되었다면 로그인 버튼 활성화
 function activateLoginBtn() {
     if( (checkEmail === true) && (checkPw === true) ){
@@ -91,8 +86,6 @@ function activateLoginBtn() {
         return false;
     }
 }
-
-
 // 로그인 버튼을 눌렀을 때, 입력된 데이터가 USER_DATA의 정보와 일치하는 경우 items 페이지로 이동, 그렇지 않은 경우 ALERT
 loginBtn.addEventListener('click', e => {
 

--- a/scripts/login.js
+++ b/scripts/login.js
@@ -15,6 +15,8 @@ const pwWrong = document.querySelector('.pwWrong');
 const pwEmpty = document.querySelector('.pwEmpty');
 const loginBtn = document.querySelector('.button');
 const toggleBtn = document.querySelector('.password-toggle-button');
+const modalButton = document.querySelector('.modal-button');
+const popUp = document.querySelector('.popUp-wrapper');
 
 // 이메일, 패스워드 정상 입력 받았는지 확인용 변수
 let checkEmail = false;
@@ -87,15 +89,27 @@ function activateLoginBtn() {
 }
 // 로그인 버튼을 눌렀을 때, 입력된 데이터가 USER_DATA의 정보와 일치하는 경우 items 페이지로 이동, 그렇지 않은 경우 ALERT
 loginBtn.addEventListener('click', e => {
-    let validate = false;
+
+    let validate = 0;
+
     for(let i = 0; i < USER_DATA.length; i++){
         if( (email.value === USER_DATA[i].email) && (password.value === USER_DATA[i].password) ){
-            validate = true;
+            validate += 1;
             window.location.href = "../items.html";
         }
     }
 
-    if(validate === false){
-        alert("APTAPT"); // 일치되는 정보 없으면 모달창 ///////////공사 예정 ///////
+        if( (email.value === window.localStorage.getItem(email.value)) && (password.value === window.localStorage.getItem(password.value)) ) {
+            validate += 1;
+            window.location.href = "../items.html";
+        }
+
+    if(validate === 0){
+        console.log("validate failed");
+        popUp.style.display = "block";
     }
+})
+
+modalButton.addEventListener('click', e => {
+    popUp.style.display = "none";
 })

--- a/scripts/login.js
+++ b/scripts/login.js
@@ -7,109 +7,97 @@ const USER_DATA = [
     { email: 'codeit6@codeit.com', password: "codeit606!" },
 ]
 
-const email = document.querySelector('#email');
-const password = document.querySelector('#password');
-const emailWrong = document.querySelector('.emailWrong');
-const emailEmpty = document.querySelector('.emailEmpty');
-const pwWrong = document.querySelector('.pwWrong');
-const pwEmpty = document.querySelector('.pwEmpty');
-const loginBtn = document.querySelector('.button');
+const loginBtn = document.querySelector('.login-button');
 const toggleBtn = document.querySelector('.password-toggle-button');
-const modalButton = document.querySelector('.modal-button');
-const popUp = document.querySelector('.popUp-wrapper');
+const popUp = document.querySelector('.popup-wrapper');
+const popupCloseBtn = document.querySelector('.modal-button');
+const email = {
+    input: document.querySelector('#email'),
+    error: document.querySelector('#emailError'),
+    empty: "이메일을 입력해주세요.",
+    wrong: "유효한 이메일 형식이 아닙니다.",
+}
+const password = {
+    input: document.querySelector('#password'),
+    error: document.querySelector('#passwordError'),
+    empty: "비밀번호를 입력해주세요",
+    wrong: "비밀번호를 8자 이상 입력해주세요",
+}
 
 // 이메일, 패스워드 정상 입력 받았는지 확인용 변수
-let checkEmail = false;
-let checkPw = false;
+let emailValidation = false;
+let passwordValidation = false;
 
-// 로그인 버튼 비활성화
-loginBtn.disabled = true;
-// 이메일 비어있는지 확인 후 @ 포함됐는지 검증
-email.addEventListener('focusout', e => {
+// 이메일 검증
+email.input.addEventListener('focusout', e => {
+    const inputValue = e.target.value;
 
-    if(email.value === ""){
-        emailWrong.style.display = "none"; //메시지 2개가 중첩될 수 있기에 하나는 none
-        emailEmpty.style.display = "block";
-        email.style.border = "2px solid #F74747";
-        email.style.outlineColor = "#F74747";
-    } else if(email.value.includes("@") === false){
-        emailEmpty.style.display = "none";
-        emailWrong.style.display = "block";
-        email.style.border = "2px solid #F74747";
-        email.style.outlineColor = "#F74747";
-    } else {
-        emailEmpty.style.display = "none";
-        emailWrong.style.display = "none";
-        email.style.border = "";
-        email.style.outlineColor = "";
-
-        checkEmail = true;
-        activateLoginBtn()
+    if(!inputValue) showMessage(email, email.empty);
+    else if(!emailValidCheck(inputValue)) showMessage(email, email.wrong);
+    else {
+        clearMessage(email);
+        emailValidation = true;
+        canEnableButton()
     }
 })
-// 패스워드 비어있는지 확인 후 8자 이상인지 검증
-password.addEventListener('focusout', e => {
-    if (password.value === ""){
-        console.log("검증함");
-        pwWrong.style.display = "none"; //메시지 2개가 중첩될 수 있기에 하나는 none
-        pwEmpty.style.display = "block";
-        password.style.border = "2px solid #F74747";
-        password.style.outlineColor = "#F74747";
-    } else if (password.value.length < 8){
-        pwEmpty.style.display = "none";
-        pwWrong.style.display = "block";
-        password.style.border = "2px solid #F74747";
-        password.style.outlineColor = "#F74747";
-    } else{
-        pwEmpty.style.display = "none";
-        pwWrong.style.display = "none";
-        password.style.border = "";
-        password.style.outlineColor = "";
+// 비밀번호 검증
+password.input.addEventListener('focusout', e => {
+    const inputValue = e.target.value;
 
-        checkPw = true;
-        activateLoginBtn()
+    if (!inputValue) showMessage(password, password.empty);
+    else if (!isOverEight(inputValue)) showMessage(password, password.wrong);
+    else {
+        clearMessage(password);
+        passwordValidation = true;
+        canEnableButton()
     }
 })
 // 비밀번호 눈 아이콘 구현
 toggleBtn.addEventListener('click', e => {
-    if(password.type === "password"){
-        password.type = "text";
-    } else {
-        password.type = "password";
-    }
+    toggleEyeButton();
 })
-// 이메일과 패스워드가 모두 정상적으로 입력되었다면 로그인 버튼 활성화
-function activateLoginBtn() {
-    if( (checkEmail === true) && (checkPw === true) ){
-        loginBtn.disabled = false;
-        return true;
-    } else {
-        return false;
-    }
-}
-// 로그인 버튼을 눌렀을 때, 입력된 데이터가 USER_DATA의 정보와 일치하는 경우 items 페이지로 이동, 그렇지 않은 경우 ALERT
+// 로그인 버튼을 눌렀을 때, 입력된 데이터가 USER_DATA의 정보와 일치하는 경우 items 페이지로 이동, 그렇지 않은 경우 팝업
 loginBtn.addEventListener('click', e => {
+    USER_DATA.some((user) => {
+        const emailValid = (user.email === email.input.value);
+        const passwordValid = (user.password === password.input.value);
 
-    let validate = 0;
-
-    for(let i = 0; i < USER_DATA.length; i++){
-        if( (email.value === USER_DATA[i].email) && (password.value === USER_DATA[i].password) ){
-            validate += 1;
-            window.location.href = "../items.html";
-        }
-    }
-
-        if( (email.value === window.localStorage.getItem(email.value)) && (password.value === window.localStorage.getItem(password.value)) ) {
-            validate += 1;
-            window.location.href = "../items.html";
-        }
-
-    if(validate === 0){
-        console.log("validate failed");
-        popUp.style.display = "block";
-    }
+        if(emailValid && passwordValid) window.location.href = "../items.html";
+        else popUp.style.display = "block";
+    })
 })
-
-modalButton.addEventListener('click', e => {
+// 팝업 확인 버튼
+popupCloseBtn.addEventListener('click', e => {
     popUp.style.display = "none";
 })
+
+
+//////////////// functions /////////////////////
+function showMessage(target, message) {
+    target.error.style.display = "block";
+    target.error.innerHTML = message;
+    target.input.style.border = "2px solid #F74747";
+    target.input.style.outlineColor = "#F74747";
+}
+function clearMessage(target) {
+    target.error.style.display = "none";
+    target.error.innerHTML = "";
+    target.input.style.border = "";
+    target.input.style.outlineColor = "";
+}
+function emailValidCheck(value) {
+    const pattern = /^[A-Za-z0-9_\.\-]+@[A-Za-z0-9\-]+\.[A-za-z0-9\-]+/;
+
+    if(pattern.test(value) === false) { return false; }
+    else { return true; }
+}
+function isOverEight(value) {
+    return (value.length >= 8);
+}
+function toggleEyeButton() {
+    if (password.input.type === "password") password.input.type = "text";
+    else password.input.type = "password";
+}
+function canEnableButton() {
+    loginBtn.disabled = !(emailValidation && passwordValidation);
+}

--- a/scripts/login.js
+++ b/scripts/login.js
@@ -23,14 +23,14 @@ let checkPw = false;
 // 로그인 버튼 비활성화
 loginBtn.disabled = true;
 // 이메일 비어있는지 확인 후 @ 포함됐는지 검증
-email.addEventListener('input', e => {
+email.addEventListener('focusout', e => {
 
-    if(e.target.value === ""){
+    if(email.value === ""){
         emailWrong.style.display = "none"; //메시지 2개가 중첩될 수 있기에 하나는 none
         emailEmpty.style.display = "block";
         email.style.border = "2px solid #F74747";
         email.style.outlineColor = "#F74747";
-    } else if(e.target.value.includes("@") === false){
+    } else if(email.value.includes("@") === false){
         emailEmpty.style.display = "none";
         emailWrong.style.display = "block";
         email.style.border = "2px solid #F74747";
@@ -46,15 +46,14 @@ email.addEventListener('input', e => {
     }
 })
 // 패스워드 비어있는지 확인 후 8자 이상인지 검증
-password.addEventListener('input', e => {
-
-    if(e.target.value === ""){
+password.addEventListener('focusout', e => {
+    if (password.value === ""){
         console.log("검증함");
         pwWrong.style.display = "none"; //메시지 2개가 중첩될 수 있기에 하나는 none
         pwEmpty.style.display = "block";
         password.style.border = "2px solid #F74747";
         password.style.outlineColor = "#F74747";
-    } else if(e.target.value.length < 8){
+    } else if (password.value.length < 8){
         pwEmpty.style.display = "none";
         pwWrong.style.display = "block";
         password.style.border = "2px solid #F74747";
@@ -88,9 +87,8 @@ function activateLoginBtn() {
 }
 // 로그인 버튼을 눌렀을 때, 입력된 데이터가 USER_DATA의 정보와 일치하는 경우 items 페이지로 이동, 그렇지 않은 경우 ALERT
 loginBtn.addEventListener('click', e => {
-
+    let validate = false;
     for(let i = 0; i < USER_DATA.length; i++){
-        let validate = false;
         if( (email.value === USER_DATA[i].email) && (password.value === USER_DATA[i].password) ){
             validate = true;
             window.location.href = "../items.html";
@@ -98,6 +96,6 @@ loginBtn.addEventListener('click', e => {
     }
 
     if(validate === false){
-        alert("APTAPT");
+        alert("APTAPT"); // 일치되는 정보 없으면 모달창 ///////////공사 예정 ///////
     }
 })

--- a/scripts/login.js
+++ b/scripts/login.js
@@ -1,0 +1,110 @@
+const USER_DATA = [
+    { email: 'codeit1@codeit.com', password: "codeit101!" },
+    { email: 'codeit2@codeit.com', password: "codeit202!" },
+    { email: 'codeit3@codeit.com', password: "codeit303!" },
+    { email: 'codeit4@codeit.com', password: "codeit404!" },
+    { email: 'codeit5@codeit.com', password: "codeit505!" },
+    { email: 'codeit6@codeit.com', password: "codeit606!" },
+]
+
+const email = document.querySelector('#email');
+const password = document.querySelector('#password');
+const emailWrong = document.querySelector('.emailWrong');
+const emailEmpty = document.querySelector('.emailEmpty');
+const pwWrong = document.querySelector('.pwWrong');
+const pwEmpty = document.querySelector('.pwEmpty');
+const loginBtn = document.querySelector('.button');
+const toggleBtn = document.querySelector('.password-toggle-button');
+
+
+// 이메일, 패스워드 정상 입력 받았는지 확인용 변수
+let checkEmail = false;
+let checkPw = false;
+
+// 로그인 버튼 비활성화
+loginBtn.disabled = true;
+
+// 이메일 비어있는지 확인 후 @ 포함됐는지 검증
+email.addEventListener('input', e => {
+
+    if(e.target.value === ""){
+        emailWrong.style.display = "none"; //메시지 2개가 중첩될 수 있기에 하나는 none
+        emailEmpty.style.display = "block";
+        email.style.border = "2px solid #F74747";
+        email.style.outlineColor = "#F74747";
+    } else if(e.target.value.includes("@") === false){
+        emailEmpty.style.display = "none";
+        emailWrong.style.display = "block";
+        email.style.border = "2px solid #F74747";
+        email.style.outlineColor = "#F74747";
+    } else {
+        emailEmpty.style.display = "none";
+        emailWrong.style.display = "none";
+        email.style.border = "";
+        email.style.outlineColor = "";
+
+        checkEmail = true;
+        activateLoginBtn()
+    }
+})
+
+// 패스워드 비어있는지 확인 후 8자 이상인지 검증
+password.addEventListener('input', e => {
+
+    if(e.target.value === ""){
+        console.log("검증함");
+        pwWrong.style.display = "none"; //메시지 2개가 중첩될 수 있기에 하나는 none
+        pwEmpty.style.display = "block";
+        password.style.border = "2px solid #F74747";
+        password.style.outlineColor = "#F74747";
+    } else if(e.target.value.length < 8){
+        pwEmpty.style.display = "none";
+        pwWrong.style.display = "block";
+        password.style.border = "2px solid #F74747";
+        password.style.outlineColor = "#F74747";
+    } else{
+        pwEmpty.style.display = "none";
+        pwWrong.style.display = "none";
+        password.style.border = "";
+        password.style.outlineColor = "";
+
+        checkPw = true;
+        activateLoginBtn()
+    }
+})
+
+// 비밀번호 눈 아이콘 구현
+toggleBtn.addEventListener('click', e => {
+    if(password.type === "password"){
+        password.type = "text";
+    } else {
+        password.type = "password";
+    }
+})
+
+// 이메일과 패스워드가 모두 정상적으로 입력되었다면 로그인 버튼 활성화
+function activateLoginBtn() {
+    if( (checkEmail === true) && (checkPw === true) ){
+        loginBtn.disabled = false;
+        return true;
+    } else {
+        return false;
+    }
+}
+
+
+// 로그인 버튼을 눌렀을 때, 입력된 데이터가 USER_DATA의 정보와 일치하는 경우 items 페이지로 이동, 그렇지 않은 경우 ALERT
+loginBtn.addEventListener('click', e => {
+
+    for(let i = 0; i < USER_DATA.length; i++){
+        let validate = false;
+        if( (email.value === USER_DATA[i].email) && (password.value === USER_DATA[i].password) ){
+            validate = true;
+            window.location.href = "../items.html";
+        }
+    }
+
+    if(validate === false){
+        alert("APTAPT");
+    }
+})

--- a/scripts/signup.js
+++ b/scripts/signup.js
@@ -17,6 +17,7 @@ const pwWrong = document.querySelector('.pwWrong');
 const pwEmpty = document.querySelector('.pwEmpty');
 const pwCWrong = document.querySelector('.pwCWrong');
 const pwCEmpty = document.querySelector('.pwCEmpty');
+const pwCEight = document.querySelector('.pwCEight');
 const signupBtn = document.querySelector('.button');
 const toggleBtn = document.querySelector('.password-toggle-button');
 const toggleCBtn = document.querySelector('.toggleC');
@@ -32,19 +33,26 @@ let checkPwC = false;
 // 로그인 버튼 비활성화
 signupBtn.disabled = true;
 
+
+// @@@@@@@@@@@@@@@@@@@@@@@@ 함수로 만들어라 @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
 // 이메일 비어있는지 확인 후 @ 포함됐는지 검증
 email.addEventListener('focusout', e => {
-
-    if (e.target.value === "") {
+    if (!e.target.value) { //이렇게 바꿔봅시다.
         emailWrong.style.display = "none"; //메시지 2개가 중첩될 수 있기에 하나는 none
         emailEmpty.style.display = "block";
         email.style.border = "2px solid #F74747";
         email.style.outlineColor = "#F74747";
+
+        checkEmail = false;
+        activateSignUpButton()
     } else if (e.target.value.includes("@") === false) {
         emailEmpty.style.display = "none";
         emailWrong.style.display = "block";
         email.style.border = "2px solid #F74747";
         email.style.outlineColor = "#F74747";
+
+        checkEmail = false;
+        activateSignUpButton()
     } else {
         emailEmpty.style.display = "none";
         emailWrong.style.display = "none";
@@ -63,11 +71,17 @@ nickname.addEventListener('focusout', e => {
         nickEmpty.style.display = "block";
         nickname.style.border = "2px solid #F74747";
         nickname.style.outlineColor = "#F74747";
+
+        checkNick = false;
+        activateSignUpButton()
     } else if (e.target.value.length < 4) {
         nickEmpty.style.display = "none";
         nickFour.style.display = "block";
         nickname.style.border = "2px solid #F74747";
         nickname.style.outlineColor = "#F74747";
+
+        checkNick = false;
+        activateSignUpButton()
     } else {
         nickEmpty.style.display = "none";
         nickFour.style.display = "none";
@@ -86,11 +100,17 @@ password.addEventListener('focusout', e => {
         pwEmpty.style.display = "block";
         password.style.border = "2px solid #F74747";
         password.style.outlineColor = "#F74747";
+
+        checkPw = false;
+        activateSignUpButton()
     } else if (e.target.value.length < 8) {
         pwEmpty.style.display = "none";
         pwWrong.style.display = "block";
         password.style.border = "2px solid #F74747";
         password.style.outlineColor = "#F74747";
+
+        checkPw = false;
+        activateSignUpButton()
     } else {
         pwEmpty.style.display = "none";
         pwWrong.style.display = "none";
@@ -111,20 +131,40 @@ toggleBtn.addEventListener('click', e => {
 })
 // 패스워드확인 비어있는지 확인 후 패스워드와 일치하는지 확인
 passwordC.addEventListener('focusout', e => {
-
-    if (e.target.value === "") {
-        pwCWrong.style.display = "none"; //메시지 2개가 중첩될 수 있기에 하나는 none
+    if (passwordC.value === "") {
+        pwCWrong.style.display = "none"; //메시지가 중첩될 수 있기에 none
+        pwCEight.style.display = "none";
         pwCEmpty.style.display = "block";
         passwordC.style.border = "2px solid #F74747";
         passwordC.style.outlineColor = "#F74747";
-    } else if (e.target.value !== password.value) {
+
+        checkPwC = false;
+        activateSignUpButton();
+
+    } else if (passwordC.value.length < 8) {
+        pwCEight.style.display = "block";
         pwCEmpty.style.display = "none";
-        pwCWrong.style.display = "block";
+        pwCWrong.style.display = "none";
         passwordC.style.border = "2px solid #F74747";
         passwordC.style.outlineColor = "#F74747";
+        console.log("비밀번호2")
+        checkPwC = false;
+        activateSignUpButton();
+
+    } else if (passwordC.value !== password.value) {
+        pwCWrong.style.display = "block";
+        pwCEmpty.style.display = "none";
+        pwCEight.style.display = "none";
+        passwordC.style.border = "2px solid #F74747";
+        passwordC.style.outlineColor = "#F74747";
+        console.log("비밀번호3")
+        checkPwC = false;
+        activateSignUpButton();
+
     } else {
         pwCWrong.style.display = "none";
         pwCEmpty.style.display = "none";
+        pwCEight.style.display = "none";
         passwordC.style.border = "";
         passwordC.style.outlineColor = "";
 
@@ -140,28 +180,32 @@ toggleCBtn.addEventListener('click', e => {
         passwordC.type = "password";
     }
 })
+
 // 이메일과 패스워드가 모두 정상적으로 입력되었다면 로그인 버튼 활성화
 function activateSignUpButton() {
-    if ( (checkEmail === true) && (checkPw === true) && (checkNick === true) && (checkPwC === true) ) {
+    if ((checkEmail && checkPw) && (checkPwC && checkNick)) { //변수로 만들어서 처리
         signupBtn.disabled = false;
-        return true;
     } else {
-        return false;
+        signupBtn.disabled = true;
     }
 }
-// USER_DATA에 중복된 이메일이 있는 경우 ALERT.
-// 회원가입 성공적으로 끝났다면 login 페이지로 이동
-signupBtn.addEventListener('click', e => {
 
+// USER_DATA에 중복된 이메일이 있는 경우 ALERT. & 정상 회원가입됐다면 login.html로 이동.
+let validate = true;
+
+signupBtn.addEventListener('click', e => {
     for (let i = 0; i < USER_DATA.length; i++) {
-        let validate = false;
-        if (!(email.value === USER_DATA[i].email)) {
-            validate = true;
-            window.location.href = "../login.html";
+        const userData = USER_DATA[i];
+        const compared = (email.value === userData.email);
+
+        if (compared) {
+            validate = false;
         }
     }
 
-    if (validate === false) {
-        alert("이메일이 이미 등록된거시와요.");
+    if (validate) {
+        window.location.href = "../login.html";
+    } else {
+        alert("THATS NONO"); //////////////////// 모달창 업데이트
     }
 })

--- a/scripts/signup.js
+++ b/scripts/signup.js
@@ -140,7 +140,6 @@ toggleCBtn.addEventListener('click', e => {
         passwordC.type = "password";
     }
 })
-
 // 이메일과 패스워드가 모두 정상적으로 입력되었다면 로그인 버튼 활성화
 function activateSignUpButton() {
     if ( (checkEmail === true) && (checkPw === true) && (checkNick === true) && (checkPwC === true) ) {
@@ -150,7 +149,6 @@ function activateSignUpButton() {
         return false;
     }
 }
-
 // USER_DATA에 중복된 이메일이 있는 경우 ALERT.
 // 회원가입 성공적으로 끝났다면 login 페이지로 이동
 signupBtn.addEventListener('click', e => {

--- a/scripts/signup.js
+++ b/scripts/signup.js
@@ -40,7 +40,7 @@ const toggleButtonPassword = document.querySelector('.password-toggle-button');
 const toggleButtonPasswordConfirm = document.querySelector('.toggleC');
 
 const modalButton = document.querySelector('.modal-button');
-const popUp = document.querySelector('.popUp-wrapper');
+const popUp = document.querySelector('.errorModal');
 
 let emailInputValue = "";
 let passwordInputValue = "";
@@ -117,15 +117,15 @@ toggleButtonPasswordConfirm.addEventListener('click', e => {
 // USER_DATA 비교하여 login.html 이동 OR 모달 메시지 출력
 signupBtn.addEventListener('click', e => {
   const isEmailExist = USER_DATA.some(function (user) {
-    (emailInputValue === user.email);
-})
+    return (emailInputValue === user.email);
+  })
 
-if (!isEmailExist) goLoginPage();
-else showExistEmailModal();
+  if (!isEmailExist) goLoginPage();
+  else showErrorModal();
 })
 
 modalButton.addEventListener('click', e => {
-  popUp.style.display = "none";
+  popUp.style.display = 'none';
 })
 
 ///////////////////// functions ///////////////////////
@@ -179,9 +179,10 @@ function passwordMatch(password, passwordConfirm) {
 }
 
 function goLoginPage() {
-  window.location.href = "../login.html";
+  // window.location.href = "../login.html";
+  console.log("GO LOGIN PAGE");
 }
 
-function showExistEmailModal() {
-  popUp.classList.add('.display');
+function showErrorModal() {
+  popUp.style.display = "block";
 }

--- a/scripts/signup.js
+++ b/scripts/signup.js
@@ -6,225 +6,123 @@ const USER_DATA = [
   {email: 'codeit5@codeit.com', password: "codeit505!"},
   {email: 'codeit6@codeit.com', password: "codeit606!"},
 ]
-const email = {
-    input: document.querySelector('#email'),
-    error: document.querySelector('#emailError'),
-    empty: "이메일을 입력해주세요.",
-    wrong: "유효한 이메일 형식이 아닙니다.",
+let email = {
+  input: document.querySelector('#email'),
+  error: document.querySelector('#emailError'),
+  empty: "이메일을 입력해주세요.",
+  wrong: "유효한 이메일 형식이 아닙니다.",
+  valid: false,
 }
-const password = {
-    input: document.querySelector('#password'),
-    error: document.querySelector('#passwordError'),
-    empty: "비밀번호를 입력해주세요",
-    wrong: "비밀번호를 8자 이상 입력해주세요",
+let password = {
+  input: document.querySelector('#password'),
+  error: document.querySelector('#passwordError'),
+  empty: "비밀번호를 입력해주세요",
+  wrong: "비밀번호를 8자 이상 입력해주세요",
+  valid: false,
 }
-const nickname = {
-    input: document.querySelector('#nickname'),
-    error: document.querySelector('#nicknameError'),
-    empty: "닉네임을 입력해주세요.",
-    wrong: "닉네임을 4자 이상 입력해주세요.",
+let nickname = {
+  input: document.querySelector('#nickname'),
+  error: document.querySelector('#nicknameError'),
+  empty: "닉네임을 입력해주세요.",
+  wrong: "닉네임을 4자 이상 입력해주세요.",
+  valid: false,
 }
-const passwordConfirm = {
-    input: document.querySelector('#passwordConfirmation'),
-    error: document.querySelector('#pwConfirmError'),
-    empty: "비밀번호를 입력해주세요",
-    wrong: "비밀번호가 일치하지 않습니다.",
+let passwordConfirm = {
+  input: document.querySelector('#passwordConfirmation'),
+  error: document.querySelector('#pwConfirmError'),
+  empty: "비밀번호를 입력해주세요",
+  wrong: "비밀번호가 일치하지 않습니다.",
+  valid: false,
 }
 
 const signupBtn = document.querySelector('.signup-button');
-const toggleBtn = document.querySelector('.password-toggle-button');
-const toggleCBtn = document.querySelector('.toggleC');
+const toggleButtonPassword = document.querySelector('.password-toggle-button');
+const toggleButtonPasswordConfirm = document.querySelector('.toggleC');
 
 const modalButton = document.querySelector('.modal-button');
 const popUp = document.querySelector('.popUp-wrapper');
 
-// 이메일, 패스워드 정상 입력 받았는지 확인용 변수
-let emailValidation = false;
-let nicknameValidation = false;
-let passwordValidation = false;
-let pwConfirmValidation = false;
-
+let emailInputValue = "";
+let passwordInputValue = "";
 
 email.input.addEventListener('focusout', e => {
-  // if (!e.target.value) { //이렇게 바꿔봅시다.
-  //   emailWrong.style.display = "none"; //메시지 2개가 중첩될 수 있기에 하나는 none
-  //   emailEmpty.style.display = "block";
-  //   email.style.border = "2px solid #F74747";
-  //   email.style.outlineColor = "#F74747";
-  //
-  //   checkEmail = false;
-  //   activateSignUpButton()
-  // } else if (e.target.value.includes("@") === false) {
-  //   emailEmpty.style.display = "none";
-  //   emailWrong.style.display = "block";
-  //   email.style.border = "2px solid #F74747";
-  //   email.style.outlineColor = "#F74747";
-  //
-  //   checkEmail = false;
-  //   activateSignUpButton()
-  // } else {
-  //   emailEmpty.style.display = "none";
-  //   emailWrong.style.display = "none";
-  //   email.style.border = "";
-  //   email.style.outlineColor = "";
-  //
-  //   checkEmail = true;
-  //   activateSignUpButton()
-  // }
-    const inputValue = e.target.value;
+  emailInputValue = e.target.value;
 
-    if (!inputValue) showMessage(email, email.empty);
-    else if (emailValidCheck(inputValue)) showMessage(email, email.wrong);
-    else clearMessage(email);
+  if (!emailInputValue) {
+    showMessage(email, email.empty);
+    canEnableButton();
+  } else if (!emailValidCheck(emailInputValue)) {
+    showMessage(email, email.wrong);
+    canEnableButton();
+  } else {
+    clearMessage(email);
+    canEnableButton();
+  }
 })
 // 닉네임칸 비었는지, 4글자 이상인지 확인
-nickname.addEventListener('focusout', e => {
+nickname.input.addEventListener('focusout', e => {
+  const inputValue = e.target.value;
 
-  if (e.target.value === "") {
-    nickFour.style.display = "none"; //메시지 2개가 중첩될 수 있기에 하나는 none
-    nickEmpty.style.display = "block";
-    nickname.style.border = "2px solid #F74747";
-    nickname.style.outlineColor = "#F74747";
-
-    checkNick = false;
-    activateSignUpButton()
-  } else if (e.target.value.length < 4) {
-    nickEmpty.style.display = "none";
-    nickFour.style.display = "block";
-    nickname.style.border = "2px solid #F74747";
-    nickname.style.outlineColor = "#F74747";
-
-    checkNick = false;
-    activateSignUpButton()
+  if (!inputValue) {
+    showMessage(nickname, nickname.empty);
+    canEnableButton();
+  } else if (!isOverFour(inputValue)) {
+    showMessage(nickname, nickname.wrong);
+    canEnableButton();
   } else {
-    nickEmpty.style.display = "none";
-    nickFour.style.display = "none";
-    nickname.style.border = "";
-    nickname.style.outlineColor = "";
-
-    checkNick = true;
-    activateSignUpButton()
+    clearMessage(nickname);
+    canEnableButton();
   }
 })
 // 패스워드 비어있는지 확인 후 8자 이상인지 검증
-password.addEventListener('focusout', e => {
+password.input.addEventListener('focusout', e => {
+  passwordInputValue = e.target.value;
 
-  if (e.target.value === "") {
-    pwWrong.style.display = "none"; //메시지 2개가 중첩될 수 있기에 하나는 none
-    pwEmpty.style.display = "block";
-    password.style.border = "2px solid #F74747";
-    password.style.outlineColor = "#F74747";
-
-    checkPw = false;
-    activateSignUpButton()
-  } else if (e.target.value.length < 8) {
-    pwEmpty.style.display = "none";
-    pwWrong.style.display = "block";
-    password.style.border = "2px solid #F74747";
-    password.style.outlineColor = "#F74747";
-
-    checkPw = false;
-    activateSignUpButton()
+  if (!passwordInputValue) {
+    showMessage(password, password.empty);
+    canEnableButton();
+  } else if (!isOverEight(passwordInputValue)) {
+    showMessage(password, password.wrong);
+    canEnableButton();
   } else {
-    pwEmpty.style.display = "none";
-    pwWrong.style.display = "none";
-    password.style.border = "";
-    password.style.outlineColor = "";
-
-    checkPw = true;
-    activateSignUpButton()
-  }
-})
-// 비밀번호 눈 아이콘 구현
-toggleBtn.addEventListener('click', e => {
-  if (password.type === "password") {
-    password.type = "text";
-  } else {
-    password.type = "password";
+    clearMessage(password);
+    canEnableButton();
   }
 })
 // 패스워드확인 비어있는지 확인 후 패스워드와 일치하는지 확인
-passwordC.addEventListener('focusout', e => {
-  if (passwordC.value === "") {
-    pwCWrong.style.display = "none"; //메시지가 중첩될 수 있기에 none
-    pwCEight.style.display = "none";
-    pwCEmpty.style.display = "block";
-    passwordC.style.border = "2px solid #F74747";
-    passwordC.style.outlineColor = "#F74747";
+passwordConfirm.input.addEventListener('focusout', e => {
+  const inputValue = e.target.value;
 
-    checkPwC = false;
-    activateSignUpButton();
-
-  } else if (passwordC.value.length < 8) {
-    pwCEight.style.display = "block";
-    pwCEmpty.style.display = "none";
-    pwCWrong.style.display = "none";
-    passwordC.style.border = "2px solid #F74747";
-    passwordC.style.outlineColor = "#F74747";
-    console.log("비밀번호2")
-    checkPwC = false;
-    activateSignUpButton();
-
-  } else if (passwordC.value !== password.value) {
-    pwCWrong.style.display = "block";
-    pwCEmpty.style.display = "none";
-    pwCEight.style.display = "none";
-    passwordC.style.border = "2px solid #F74747";
-    passwordC.style.outlineColor = "#F74747";
-    console.log("비밀번호3")
-    checkPwC = false;
-    activateSignUpButton();
-
+  if (!inputValue) {
+    showMessage(passwordConfirm, passwordConfirm.empty);
+    canEnableButton();
+  } else if (!passwordMatch(inputValue, passwordInputValue)) {
+    showMessage(passwordConfirm, passwordConfirm.wrong);
+    canEnableButton();
   } else {
-    pwCWrong.style.display = "none";
-    pwCEmpty.style.display = "none";
-    pwCEight.style.display = "none";
-    passwordC.style.border = "";
-    passwordC.style.outlineColor = "";
-
-    checkPwC = true;
-    activateSignUpButton()
-  }
-})
-// 패스워드확인 눈 아이콘 구현
-toggleCBtn.addEventListener('click', e => {
-  if (passwordC.type === "password") {
-    passwordC.type = "text";
-  } else {
-    passwordC.type = "password";
+    clearMessage(passwordConfirm);
+    canEnableButton();
   }
 })
 
-// 이메일과 패스워드가 모두 정상적으로 입력되었다면 로그인 버튼 활성화
-function activateSignUpButton() {
-  signupBtn.disabled = !((checkEmail && checkPw) && (checkPwC && checkNick));
-}
+// 비밀번호 토글 아이콘 구현
+toggleButtonPassword.addEventListener('click', e => {
+  toggleEyeButton(password);
+})
+// 비밀번호 확인 토글 아이콘 구현
+toggleButtonPasswordConfirm.addEventListener('click', e => {
+  toggleEyeButton(passwordConfirm);
+})
 
-// USER_DATA에 중복된 이메일이 있는 경우 ALERT. & 정상 회원가입됐다면 login.html로 이동.
+// USER_DATA 비교하여 login.html 이동 OR 모달 메시지 출력
+signupBtn.addEventListener('click', e => {
+  const isEmailExist = USER_DATA.some(function (user) {
+    (emailInputValue === user.email);
+})
 
-signupBtn.addEventListener('click',
-  e => {
-    let validate = 0;
-
-    for (let i = 0; i < USER_DATA.length; i++) {
-      const userData = USER_DATA[i];
-
-      if (email.value === userData.email) {
-        validate += 1;
-      }
-    }
-
-    if (validate === 0) {
-      window.localStorage.setItem(email.value, email.value);
-      window.localStorage.setItem(password.value, password.value);
-      console.log(window.localStorage.getItem(email.value));
-      console.log(window.localStorage.getItem(password.value));
-      window.location.href = "../login.html";
-    } else {
-      popUp.style.display = "block";
-    }
-  })
-
+if (!isEmailExist) goLoginPage();
+else showExistEmailModal();
+})
 
 modalButton.addEventListener('click', e => {
   popUp.style.display = "none";
@@ -232,30 +130,58 @@ modalButton.addEventListener('click', e => {
 
 ///////////////////// functions ///////////////////////
 function showMessage(target, message) {
-    target.error.style.display = "block";
-    target.error.innerHTML = message;
-    target.input.style.border = "2px solid #F74747";
-    target.input.style.outlineColor = "#F74747";
-}
-function clearMessage(target) {
-    target.error.style.display = "none";
-    target.error.innerHTML = "";
-    target.input.style.border = "";
-    target.input.style.outlineColor = "";
-}
-function emailValidCheck(value) {
-    const pattern = /^[A-Za-z0-9_\.\-]+@[A-Za-z0-9\-]+\.[A-za-z0-9\-]+/;
+  target.error.style.display = "block";
+  target.error.innerHTML = message;
+  target.input.style.border = "2px solid #F74747";
+  target.input.style.outlineColor = "#F74747";
 
-    if(pattern.test(value) === false) { return false; }
-    else { return true; }
+  return target.valid = false;
 }
+
+function clearMessage(target) {
+  target.error.style.display = "none";
+  target.error.innerHTML = "";
+  target.input.style.border = "";
+  target.input.style.outlineColor = "";
+
+  return target.valid = true;
+}
+
+function emailValidCheck(value) {
+  const pattern = /^[A-Za-z0-9_\.\-]+@[A-Za-z0-9\-]+\.[A-za-z0-9\-]+/;
+
+  if (pattern.test(value) === false) {
+    return false;
+  } else {
+    return true;
+  }
+}
+
 function isOverEight(value) {
-    return (value.length >= 8);
+  return (value.length >= 8);
 }
-function toggleEyeButton() {
-    if (password.input.type === "password") password.input.type = "text";
-    else password.input.type = "password";
+
+function toggleEyeButton(target) {
+  if (target.input.type === "password") target.input.type = "text";
+  else target.input.type = "password";
 }
+
 function canEnableButton() {
-    loginBtn.disabled = !(emailValidation && passwordValidation);
+  signupBtn.disabled = !(email.valid && nickname.valid && password.valid && passwordConfirm.valid);
+}
+
+function isOverFour(value) {
+  return (value.length >= 4);
+}
+
+function passwordMatch(password, passwordConfirm) {
+  return (password === passwordConfirm);
+}
+
+function goLoginPage() {
+  window.location.href = "../login.html";
+}
+
+function showExistEmailModal() {
+  popUp.classList.add('.display');
 }

--- a/scripts/signup.js
+++ b/scripts/signup.js
@@ -1,219 +1,261 @@
 const USER_DATA = [
-    {email: 'codeit1@codeit.com', password: "codeit101!"},
-    {email: 'codeit2@codeit.com', password: "codeit202!"},
-    {email: 'codeit3@codeit.com', password: "codeit303!"},
-    {email: 'codeit4@codeit.com', password: "codeit404!"},
-    {email: 'codeit5@codeit.com', password: "codeit505!"},
-    {email: 'codeit6@codeit.com', password: "codeit606!"},
+  {email: 'codeit1@codeit.com', password: "codeit101!"},
+  {email: 'codeit2@codeit.com', password: "codeit202!"},
+  {email: 'codeit3@codeit.com', password: "codeit303!"},
+  {email: 'codeit4@codeit.com', password: "codeit404!"},
+  {email: 'codeit5@codeit.com', password: "codeit505!"},
+  {email: 'codeit6@codeit.com', password: "codeit606!"},
 ]
+const email = {
+    input: document.querySelector('#email'),
+    error: document.querySelector('#emailError'),
+    empty: "이메일을 입력해주세요.",
+    wrong: "유효한 이메일 형식이 아닙니다.",
+}
+const password = {
+    input: document.querySelector('#password'),
+    error: document.querySelector('#passwordError'),
+    empty: "비밀번호를 입력해주세요",
+    wrong: "비밀번호를 8자 이상 입력해주세요",
+}
+const nickname = {
+    input: document.querySelector('#nickname'),
+    error: document.querySelector('#nicknameError'),
+    empty: "닉네임을 입력해주세요.",
+    wrong: "닉네임을 4자 이상 입력해주세요.",
+}
+const passwordConfirm = {
+    input: document.querySelector('#passwordConfirmation'),
+    error: document.querySelector('#pwConfirmError'),
+    empty: "비밀번호를 입력해주세요",
+    wrong: "비밀번호가 일치하지 않습니다.",
+}
 
-const email = document.querySelector('#email');
-const password = document.querySelector('#password');
-const passwordC = document.querySelector('#passwordConfirmation');
-const nickname = document.querySelector('#nickname');
-const emailWrong = document.querySelector('.emailWrong');
-const emailEmpty = document.querySelector('.emailEmpty');
-const pwWrong = document.querySelector('.pwWrong');
-const pwEmpty = document.querySelector('.pwEmpty');
-const pwCWrong = document.querySelector('.pwCWrong');
-const pwCEmpty = document.querySelector('.pwCEmpty');
-const pwCEight = document.querySelector('.pwCEight');
-const signupBtn = document.querySelector('.button');
+const signupBtn = document.querySelector('.signup-button');
 const toggleBtn = document.querySelector('.password-toggle-button');
 const toggleCBtn = document.querySelector('.toggleC');
-const nickEmpty = document.querySelector('.nickEmpty');
-const nickFour = document.querySelector('.nickFour');
+
 const modalButton = document.querySelector('.modal-button');
 const popUp = document.querySelector('.popUp-wrapper');
 
 // 이메일, 패스워드 정상 입력 받았는지 확인용 변수
-let checkEmail = false;
-let checkNick = false;
-let checkPw = false;
-let checkPwC = false;
-
-// 로그인 버튼 비활성화
-signupBtn.disabled = true;
+let emailValidation = false;
+let nicknameValidation = false;
+let passwordValidation = false;
+let pwConfirmValidation = false;
 
 
-// @@@@@@@@@@@@@@@@@@@@@@@@ 함수로 만들어라 @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
-// 이메일 비어있는지 확인 후 @ 포함됐는지 검증
-email.addEventListener('focusout', e => {
-    if (!e.target.value) { //이렇게 바꿔봅시다.
-        emailWrong.style.display = "none"; //메시지 2개가 중첩될 수 있기에 하나는 none
-        emailEmpty.style.display = "block";
-        email.style.border = "2px solid #F74747";
-        email.style.outlineColor = "#F74747";
+email.input.addEventListener('focusout', e => {
+  // if (!e.target.value) { //이렇게 바꿔봅시다.
+  //   emailWrong.style.display = "none"; //메시지 2개가 중첩될 수 있기에 하나는 none
+  //   emailEmpty.style.display = "block";
+  //   email.style.border = "2px solid #F74747";
+  //   email.style.outlineColor = "#F74747";
+  //
+  //   checkEmail = false;
+  //   activateSignUpButton()
+  // } else if (e.target.value.includes("@") === false) {
+  //   emailEmpty.style.display = "none";
+  //   emailWrong.style.display = "block";
+  //   email.style.border = "2px solid #F74747";
+  //   email.style.outlineColor = "#F74747";
+  //
+  //   checkEmail = false;
+  //   activateSignUpButton()
+  // } else {
+  //   emailEmpty.style.display = "none";
+  //   emailWrong.style.display = "none";
+  //   email.style.border = "";
+  //   email.style.outlineColor = "";
+  //
+  //   checkEmail = true;
+  //   activateSignUpButton()
+  // }
+    const inputValue = e.target.value;
 
-        checkEmail = false;
-        activateSignUpButton()
-    } else if (e.target.value.includes("@") === false) {
-        emailEmpty.style.display = "none";
-        emailWrong.style.display = "block";
-        email.style.border = "2px solid #F74747";
-        email.style.outlineColor = "#F74747";
-
-        checkEmail = false;
-        activateSignUpButton()
-    } else {
-        emailEmpty.style.display = "none";
-        emailWrong.style.display = "none";
-        email.style.border = "";
-        email.style.outlineColor = "";
-
-        checkEmail = true;
-        activateSignUpButton()
-    }
+    if (!inputValue) showMessage(email, email.empty);
+    else if (emailValidCheck(inputValue)) showMessage(email, email.wrong);
+    else clearMessage(email);
 })
 // 닉네임칸 비었는지, 4글자 이상인지 확인
 nickname.addEventListener('focusout', e => {
 
-    if (e.target.value === "") {
-        nickFour.style.display = "none"; //메시지 2개가 중첩될 수 있기에 하나는 none
-        nickEmpty.style.display = "block";
-        nickname.style.border = "2px solid #F74747";
-        nickname.style.outlineColor = "#F74747";
+  if (e.target.value === "") {
+    nickFour.style.display = "none"; //메시지 2개가 중첩될 수 있기에 하나는 none
+    nickEmpty.style.display = "block";
+    nickname.style.border = "2px solid #F74747";
+    nickname.style.outlineColor = "#F74747";
 
-        checkNick = false;
-        activateSignUpButton()
-    } else if (e.target.value.length < 4) {
-        nickEmpty.style.display = "none";
-        nickFour.style.display = "block";
-        nickname.style.border = "2px solid #F74747";
-        nickname.style.outlineColor = "#F74747";
+    checkNick = false;
+    activateSignUpButton()
+  } else if (e.target.value.length < 4) {
+    nickEmpty.style.display = "none";
+    nickFour.style.display = "block";
+    nickname.style.border = "2px solid #F74747";
+    nickname.style.outlineColor = "#F74747";
 
-        checkNick = false;
-        activateSignUpButton()
-    } else {
-        nickEmpty.style.display = "none";
-        nickFour.style.display = "none";
-        nickname.style.border = "";
-        nickname.style.outlineColor = "";
+    checkNick = false;
+    activateSignUpButton()
+  } else {
+    nickEmpty.style.display = "none";
+    nickFour.style.display = "none";
+    nickname.style.border = "";
+    nickname.style.outlineColor = "";
 
-        checkNick = true;
-        activateSignUpButton()
-    }
+    checkNick = true;
+    activateSignUpButton()
+  }
 })
 // 패스워드 비어있는지 확인 후 8자 이상인지 검증
 password.addEventListener('focusout', e => {
 
-    if (e.target.value === "") {
-        pwWrong.style.display = "none"; //메시지 2개가 중첩될 수 있기에 하나는 none
-        pwEmpty.style.display = "block";
-        password.style.border = "2px solid #F74747";
-        password.style.outlineColor = "#F74747";
+  if (e.target.value === "") {
+    pwWrong.style.display = "none"; //메시지 2개가 중첩될 수 있기에 하나는 none
+    pwEmpty.style.display = "block";
+    password.style.border = "2px solid #F74747";
+    password.style.outlineColor = "#F74747";
 
-        checkPw = false;
-        activateSignUpButton()
-    } else if (e.target.value.length < 8) {
-        pwEmpty.style.display = "none";
-        pwWrong.style.display = "block";
-        password.style.border = "2px solid #F74747";
-        password.style.outlineColor = "#F74747";
+    checkPw = false;
+    activateSignUpButton()
+  } else if (e.target.value.length < 8) {
+    pwEmpty.style.display = "none";
+    pwWrong.style.display = "block";
+    password.style.border = "2px solid #F74747";
+    password.style.outlineColor = "#F74747";
 
-        checkPw = false;
-        activateSignUpButton()
-    } else {
-        pwEmpty.style.display = "none";
-        pwWrong.style.display = "none";
-        password.style.border = "";
-        password.style.outlineColor = "";
+    checkPw = false;
+    activateSignUpButton()
+  } else {
+    pwEmpty.style.display = "none";
+    pwWrong.style.display = "none";
+    password.style.border = "";
+    password.style.outlineColor = "";
 
-        checkPw = true;
-        activateSignUpButton()
-    }
+    checkPw = true;
+    activateSignUpButton()
+  }
 })
 // 비밀번호 눈 아이콘 구현
 toggleBtn.addEventListener('click', e => {
-    if (password.type === "password") {
-        password.type = "text";
-    } else {
-        password.type = "password";
-    }
+  if (password.type === "password") {
+    password.type = "text";
+  } else {
+    password.type = "password";
+  }
 })
 // 패스워드확인 비어있는지 확인 후 패스워드와 일치하는지 확인
 passwordC.addEventListener('focusout', e => {
-    if (passwordC.value === "") {
-        pwCWrong.style.display = "none"; //메시지가 중첩될 수 있기에 none
-        pwCEight.style.display = "none";
-        pwCEmpty.style.display = "block";
-        passwordC.style.border = "2px solid #F74747";
-        passwordC.style.outlineColor = "#F74747";
+  if (passwordC.value === "") {
+    pwCWrong.style.display = "none"; //메시지가 중첩될 수 있기에 none
+    pwCEight.style.display = "none";
+    pwCEmpty.style.display = "block";
+    passwordC.style.border = "2px solid #F74747";
+    passwordC.style.outlineColor = "#F74747";
 
-        checkPwC = false;
-        activateSignUpButton();
+    checkPwC = false;
+    activateSignUpButton();
 
-    } else if (passwordC.value.length < 8) {
-        pwCEight.style.display = "block";
-        pwCEmpty.style.display = "none";
-        pwCWrong.style.display = "none";
-        passwordC.style.border = "2px solid #F74747";
-        passwordC.style.outlineColor = "#F74747";
-        console.log("비밀번호2")
-        checkPwC = false;
-        activateSignUpButton();
+  } else if (passwordC.value.length < 8) {
+    pwCEight.style.display = "block";
+    pwCEmpty.style.display = "none";
+    pwCWrong.style.display = "none";
+    passwordC.style.border = "2px solid #F74747";
+    passwordC.style.outlineColor = "#F74747";
+    console.log("비밀번호2")
+    checkPwC = false;
+    activateSignUpButton();
 
-    } else if (passwordC.value !== password.value) {
-        pwCWrong.style.display = "block";
-        pwCEmpty.style.display = "none";
-        pwCEight.style.display = "none";
-        passwordC.style.border = "2px solid #F74747";
-        passwordC.style.outlineColor = "#F74747";
-        console.log("비밀번호3")
-        checkPwC = false;
-        activateSignUpButton();
+  } else if (passwordC.value !== password.value) {
+    pwCWrong.style.display = "block";
+    pwCEmpty.style.display = "none";
+    pwCEight.style.display = "none";
+    passwordC.style.border = "2px solid #F74747";
+    passwordC.style.outlineColor = "#F74747";
+    console.log("비밀번호3")
+    checkPwC = false;
+    activateSignUpButton();
 
-    } else {
-        pwCWrong.style.display = "none";
-        pwCEmpty.style.display = "none";
-        pwCEight.style.display = "none";
-        passwordC.style.border = "";
-        passwordC.style.outlineColor = "";
+  } else {
+    pwCWrong.style.display = "none";
+    pwCEmpty.style.display = "none";
+    pwCEight.style.display = "none";
+    passwordC.style.border = "";
+    passwordC.style.outlineColor = "";
 
-        checkPwC = true;
-        activateSignUpButton()
-    }
+    checkPwC = true;
+    activateSignUpButton()
+  }
 })
 // 패스워드확인 눈 아이콘 구현
 toggleCBtn.addEventListener('click', e => {
-    if (passwordC.type === "password") {
-        passwordC.type = "text";
-    } else {
-        passwordC.type = "password";
-    }
+  if (passwordC.type === "password") {
+    passwordC.type = "text";
+  } else {
+    passwordC.type = "password";
+  }
 })
 
 // 이메일과 패스워드가 모두 정상적으로 입력되었다면 로그인 버튼 활성화
 function activateSignUpButton() {
-    signupBtn.disabled = !((checkEmail && checkPw) && (checkPwC && checkNick));
+  signupBtn.disabled = !((checkEmail && checkPw) && (checkPwC && checkNick));
 }
 
 // USER_DATA에 중복된 이메일이 있는 경우 ALERT. & 정상 회원가입됐다면 login.html로 이동.
 
 signupBtn.addEventListener('click',
-    e => {
-        let validate = 0;
+  e => {
+    let validate = 0;
 
-        for (let i = 0; i < USER_DATA.length; i++) {
-            const userData = USER_DATA[i];
+    for (let i = 0; i < USER_DATA.length; i++) {
+      const userData = USER_DATA[i];
 
-            if (email.value === userData.email) {
-                validate += 1;
-            }
-        }
+      if (email.value === userData.email) {
+        validate += 1;
+      }
+    }
 
-        if (validate === 0) {
-            window.localStorage.setItem(email.value, email.value);
-            window.localStorage.setItem(password.value, password.value);
-            console.log(window.localStorage.getItem(email.value));
-            console.log(window.localStorage.getItem(password.value));
-            window.location.href = "../login.html";
-        } else {
-            popUp.style.display = "block";
-        }
-    })
+    if (validate === 0) {
+      window.localStorage.setItem(email.value, email.value);
+      window.localStorage.setItem(password.value, password.value);
+      console.log(window.localStorage.getItem(email.value));
+      console.log(window.localStorage.getItem(password.value));
+      window.location.href = "../login.html";
+    } else {
+      popUp.style.display = "block";
+    }
+  })
 
 
 modalButton.addEventListener('click', e => {
-    popUp.style.display = "none";
+  popUp.style.display = "none";
 })
+
+///////////////////// functions ///////////////////////
+function showMessage(target, message) {
+    target.error.style.display = "block";
+    target.error.innerHTML = message;
+    target.input.style.border = "2px solid #F74747";
+    target.input.style.outlineColor = "#F74747";
+}
+function clearMessage(target) {
+    target.error.style.display = "none";
+    target.error.innerHTML = "";
+    target.input.style.border = "";
+    target.input.style.outlineColor = "";
+}
+function emailValidCheck(value) {
+    const pattern = /^[A-Za-z0-9_\.\-]+@[A-Za-z0-9\-]+\.[A-za-z0-9\-]+/;
+
+    if(pattern.test(value) === false) { return false; }
+    else { return true; }
+}
+function isOverEight(value) {
+    return (value.length >= 8);
+}
+function toggleEyeButton() {
+    if (password.input.type === "password") password.input.type = "text";
+    else password.input.type = "password";
+}
+function canEnableButton() {
+    loginBtn.disabled = !(emailValidation && passwordValidation);
+}

--- a/scripts/signup.js
+++ b/scripts/signup.js
@@ -1,0 +1,169 @@
+const USER_DATA = [
+    {email: 'codeit1@codeit.com', password: "codeit101!"},
+    {email: 'codeit2@codeit.com', password: "codeit202!"},
+    {email: 'codeit3@codeit.com', password: "codeit303!"},
+    {email: 'codeit4@codeit.com', password: "codeit404!"},
+    {email: 'codeit5@codeit.com', password: "codeit505!"},
+    {email: 'codeit6@codeit.com', password: "codeit606!"},
+]
+
+const email = document.querySelector('#email');
+const password = document.querySelector('#password');
+const passwordC = document.querySelector('#passwordConfirmation');
+const nickname = document.querySelector('#nickname');
+const emailWrong = document.querySelector('.emailWrong');
+const emailEmpty = document.querySelector('.emailEmpty');
+const pwWrong = document.querySelector('.pwWrong');
+const pwEmpty = document.querySelector('.pwEmpty');
+const pwCWrong = document.querySelector('.pwCWrong');
+const pwCEmpty = document.querySelector('.pwCEmpty');
+const signupBtn = document.querySelector('.button');
+const toggleBtn = document.querySelector('.password-toggle-button');
+const toggleCBtn = document.querySelector('.toggleC');
+const nickEmpty = document.querySelector('.nickEmpty');
+const nickFour = document.querySelector('.nickFour');
+
+// 이메일, 패스워드 정상 입력 받았는지 확인용 변수
+let checkEmail = false;
+let checkNick = false;
+let checkPw = false;
+let checkPwC = false;
+
+// 로그인 버튼 비활성화
+signupBtn.disabled = true;
+
+// 이메일 비어있는지 확인 후 @ 포함됐는지 검증
+email.addEventListener('focusout', e => {
+
+    if (e.target.value === "") {
+        emailWrong.style.display = "none"; //메시지 2개가 중첩될 수 있기에 하나는 none
+        emailEmpty.style.display = "block";
+        email.style.border = "2px solid #F74747";
+        email.style.outlineColor = "#F74747";
+    } else if (e.target.value.includes("@") === false) {
+        emailEmpty.style.display = "none";
+        emailWrong.style.display = "block";
+        email.style.border = "2px solid #F74747";
+        email.style.outlineColor = "#F74747";
+    } else {
+        emailEmpty.style.display = "none";
+        emailWrong.style.display = "none";
+        email.style.border = "";
+        email.style.outlineColor = "";
+
+        checkEmail = true;
+        activateSignUpButton()
+    }
+})
+// 닉네임칸 비었는지, 4글자 이상인지 확인
+nickname.addEventListener('focusout', e => {
+
+    if (e.target.value === "") {
+        nickFour.style.display = "none"; //메시지 2개가 중첩될 수 있기에 하나는 none
+        nickEmpty.style.display = "block";
+        nickname.style.border = "2px solid #F74747";
+        nickname.style.outlineColor = "#F74747";
+    } else if (e.target.value.length < 4) {
+        nickEmpty.style.display = "none";
+        nickFour.style.display = "block";
+        nickname.style.border = "2px solid #F74747";
+        nickname.style.outlineColor = "#F74747";
+    } else {
+        nickEmpty.style.display = "none";
+        nickFour.style.display = "none";
+        nickname.style.border = "";
+        nickname.style.outlineColor = "";
+
+        checkNick = true;
+        activateSignUpButton()
+    }
+})
+// 패스워드 비어있는지 확인 후 8자 이상인지 검증
+password.addEventListener('focusout', e => {
+
+    if (e.target.value === "") {
+        pwWrong.style.display = "none"; //메시지 2개가 중첩될 수 있기에 하나는 none
+        pwEmpty.style.display = "block";
+        password.style.border = "2px solid #F74747";
+        password.style.outlineColor = "#F74747";
+    } else if (e.target.value.length < 8) {
+        pwEmpty.style.display = "none";
+        pwWrong.style.display = "block";
+        password.style.border = "2px solid #F74747";
+        password.style.outlineColor = "#F74747";
+    } else {
+        pwEmpty.style.display = "none";
+        pwWrong.style.display = "none";
+        password.style.border = "";
+        password.style.outlineColor = "";
+
+        checkPw = true;
+        activateSignUpButton()
+    }
+})
+// 비밀번호 눈 아이콘 구현
+toggleBtn.addEventListener('click', e => {
+    if (password.type === "password") {
+        password.type = "text";
+    } else {
+        password.type = "password";
+    }
+})
+// 패스워드확인 비어있는지 확인 후 패스워드와 일치하는지 확인
+passwordC.addEventListener('focusout', e => {
+
+    if (e.target.value === "") {
+        pwCWrong.style.display = "none"; //메시지 2개가 중첩될 수 있기에 하나는 none
+        pwCEmpty.style.display = "block";
+        passwordC.style.border = "2px solid #F74747";
+        passwordC.style.outlineColor = "#F74747";
+    } else if (e.target.value !== password.value) {
+        pwCEmpty.style.display = "none";
+        pwCWrong.style.display = "block";
+        passwordC.style.border = "2px solid #F74747";
+        passwordC.style.outlineColor = "#F74747";
+    } else {
+        pwCWrong.style.display = "none";
+        pwCEmpty.style.display = "none";
+        passwordC.style.border = "";
+        passwordC.style.outlineColor = "";
+
+        checkPwC = true;
+        activateSignUpButton()
+    }
+})
+// 패스워드확인 눈 아이콘 구현
+toggleCBtn.addEventListener('click', e => {
+    if (passwordC.type === "password") {
+        passwordC.type = "text";
+    } else {
+        passwordC.type = "password";
+    }
+})
+
+// 이메일과 패스워드가 모두 정상적으로 입력되었다면 로그인 버튼 활성화
+function activateSignUpButton() {
+    if ( (checkEmail === true) && (checkPw === true) && (checkNick === true) && (checkPwC === true) ) {
+        signupBtn.disabled = false;
+        return true;
+    } else {
+        return false;
+    }
+}
+
+// USER_DATA에 중복된 이메일이 있는 경우 ALERT.
+// 회원가입 성공적으로 끝났다면 login 페이지로 이동
+signupBtn.addEventListener('click', e => {
+
+    for (let i = 0; i < USER_DATA.length; i++) {
+        let validate = false;
+        if (!(email.value === USER_DATA[i].email)) {
+            validate = true;
+            window.location.href = "../login.html";
+        }
+    }
+
+    if (validate === false) {
+        alert("이메일이 이미 등록된거시와요.");
+    }
+})

--- a/scripts/signup.js
+++ b/scripts/signup.js
@@ -183,11 +183,7 @@ toggleCBtn.addEventListener('click', e => {
 
 // 이메일과 패스워드가 모두 정상적으로 입력되었다면 로그인 버튼 활성화
 function activateSignUpButton() {
-    if ((checkEmail && checkPw) && (checkPwC && checkNick)) { //변수로 만들어서 처리
-        signupBtn.disabled = false;
-    } else {
-        signupBtn.disabled = true;
-    }
+    signupBtn.disabled = !((checkEmail && checkPw) && (checkPwC && checkNick));
 }
 
 // USER_DATA에 중복된 이메일이 있는 경우 ALERT. & 정상 회원가입됐다면 login.html로 이동.

--- a/scripts/signup.js
+++ b/scripts/signup.js
@@ -23,6 +23,8 @@ const toggleBtn = document.querySelector('.password-toggle-button');
 const toggleCBtn = document.querySelector('.toggleC');
 const nickEmpty = document.querySelector('.nickEmpty');
 const nickFour = document.querySelector('.nickFour');
+const modalButton = document.querySelector('.modal-button');
+const popUp = document.querySelector('.popUp-wrapper');
 
 // 이메일, 패스워드 정상 입력 받았는지 확인용 변수
 let checkEmail = false;
@@ -187,21 +189,31 @@ function activateSignUpButton() {
 }
 
 // USER_DATA에 중복된 이메일이 있는 경우 ALERT. & 정상 회원가입됐다면 login.html로 이동.
-let validate = true;
 
-signupBtn.addEventListener('click', e => {
-    for (let i = 0; i < USER_DATA.length; i++) {
-        const userData = USER_DATA[i];
-        const compared = (email.value === userData.email);
+signupBtn.addEventListener('click',
+    e => {
+        let validate = 0;
 
-        if (compared) {
-            validate = false;
+        for (let i = 0; i < USER_DATA.length; i++) {
+            const userData = USER_DATA[i];
+
+            if (email.value === userData.email) {
+                validate += 1;
+            }
         }
-    }
 
-    if (validate) {
-        window.location.href = "../login.html";
-    } else {
-        alert("THATS NONO"); //////////////////// 모달창 업데이트
-    }
+        if (validate === 0) {
+            window.localStorage.setItem(email.value, email.value);
+            window.localStorage.setItem(password.value, password.value);
+            console.log(window.localStorage.getItem(email.value));
+            console.log(window.localStorage.getItem(password.value));
+            window.location.href = "../login.html";
+        } else {
+            popUp.style.display = "block";
+        }
+    })
+
+
+modalButton.addEventListener('click', e => {
+    popUp.style.display = "none";
 })

--- a/signup.html
+++ b/signup.html
@@ -93,6 +93,7 @@
             </button>
           </div>
           <p class="pwCEmpty">비밀번호 확인란을 입력해주세요.</p>
+          <p class="pwCEight">비밀번호를 8자 이상 입력해주세요.</p>
           <p class="pwCWrong">비밀번호가 일치하지 않습니다.</p>
         </div>
 

--- a/signup.html
+++ b/signup.html
@@ -128,7 +128,7 @@
       </div>
     </main>
 
-    <div class="popup-wrapper">
+    <div class="errorModal">
       <div class="popUp">
         <p>사용 중인 이메일입니다.</p>
         <button class="modal-button">확인</button>

--- a/signup.html
+++ b/signup.html
@@ -32,6 +32,9 @@
             type="email"
             placeholder="이메일을 입력해 주세요"
           />
+          <p class="emailEmpty">이메일을 입력해주세요.</p>
+          <p class="emailWrong">잘못된 이메일 형식입니다.</p>
+
         </div>
         <div class="input-item">
           <label for="nickname">닉네임</label>
@@ -41,6 +44,9 @@
             type="text"
             placeholder="닉네임을 입력해 주세요"
           />
+          <p class="nickEmpty">닉네임을 입력해주세요.</p>
+          <p class="nickFour">닉네임은 4글자 이상으로 정해주세요.</p>
+
         </div>
         <div class="input-item">
           <label for="password">비밀번호</label>
@@ -51,7 +57,7 @@
               type="password"
               placeholder="비밀번호를 입력해 주세요"
             />
-            <!-- [심화 요구사항] 비밀번호, 비밀번호 확인 input 요소 오른쪽에 비밀번호를 확인할 수 있는 눈 모양 아이콘을 추가합니다. -->
+            <!-- [심화 요구사항] 비밀번호, 비밀번호 확인 input 요소 오른쪽에는 눈 모양 아 비밀번호를 확인할 수 있는 눈 모양 아이콘을 추가합니다. -->
             <button
               type="button"
               class="password-toggle-button"
@@ -63,6 +69,8 @@
               />
             </button>
           </div>
+          <p class="pwEmpty">비밀번호를 입력해주세요.</p>
+          <p class="pwWrong">비밀번호를 8자 이상 입력해주세요.</p>
         </div>
         <div class="input-item">
           <label for="passwordConfirmation">비밀번호 확인</label>
@@ -75,7 +83,7 @@
             />
             <button
               type="button"
-              class="password-toggle-button"
+              class="password-toggle-button toggleC"
               aria-label="비밀번호 보기"
             >
               <img
@@ -84,9 +92,11 @@
               />
             </button>
           </div>
+          <p class="pwCEmpty">비밀번호 확인란을 입력해주세요.</p>
+          <p class="pwCWrong">비밀번호가 일치하지 않습니다.</p>
         </div>
 
-        <button type="submit" class="button pill-button full-width">
+        <button type="button" class="button pill-button full-width">
           회원가입
         </button>
       </form>

--- a/signup.html
+++ b/signup.html
@@ -32,8 +32,7 @@
             type="email"
             placeholder="이메일을 입력해 주세요"
           />
-          <p class="emailEmpty">이메일을 입력해주세요.</p>
-          <p class="emailWrong">잘못된 이메일 형식입니다.</p>
+          <p id="emailError">이메일을 입력해주세요.</p>
 
         </div>
         <div class="input-item">
@@ -44,8 +43,7 @@
             type="text"
             placeholder="닉네임을 입력해 주세요"
           />
-          <p class="nickEmpty">닉네임을 입력해주세요.</p>
-          <p class="nickFour">닉네임은 4글자 이상으로 정해주세요.</p>
+          <p id="nicknameError">닉네임을 입력해주세요.</p>
 
         </div>
         <div class="input-item">
@@ -69,8 +67,7 @@
               />
             </button>
           </div>
-          <p class="pwEmpty">비밀번호를 입력해주세요.</p>
-          <p class="pwWrong">비밀번호를 8자 이상 입력해주세요.</p>
+          <p id="passwordError">비밀번호를 입력해주세요.</p>
         </div>
         <div class="input-item">
           <label for="passwordConfirmation">비밀번호 확인</label>
@@ -92,12 +89,10 @@
               />
             </button>
           </div>
-          <p class="pwCEmpty">비밀번호 확인란을 입력해주세요.</p>
-          <p class="pwCEight">비밀번호를 8자 이상 입력해주세요.</p>
-          <p class="pwCWrong">비밀번호가 일치하지 않습니다.</p>
+          <p id="pwConfirmError">비밀번호 확인란을 입력해주세요.</p>
         </div>
 
-        <button type="button" class="button pill-button full-width">
+        <button type="button" class="signup-button button pill-button full-width" disabled>
           회원가입
         </button>
       </form>
@@ -133,7 +128,7 @@
       </div>
     </main>
 
-    <div class="popUp-wrapper">
+    <div class="popup-wrapper">
       <div class="popUp">
         <p>사용 중인 이메일입니다.</p>
         <button class="modal-button">확인</button>

--- a/signup.html
+++ b/signup.html
@@ -11,15 +11,15 @@
       crossorigin
       href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/static/pretendard.min.css"
     />
-    <link rel="stylesheet" href="styles/global.css" />
-    <link rel="stylesheet" href="styles/auth.css" />
+    <link rel="stylesheet" href="/styles/global.css" />
+    <link rel="stylesheet" href="/styles/auth.css" />
   </head>
 
   <body>
     <main class="auth-container">
       <div class="logo-home-button-wrapper">
         <a href="/"
-          ><img src="images/logo/logo.svg" alt="판다마켓 홈" width="396"
+          ><img src="/images/logo/logo.svg" alt="판다마켓 홈" width="396"
         /></a>
       </div>
 
@@ -111,7 +111,7 @@
             rel="noopener noreferrer"
             aria-label="구글 로그인"
             ><img
-              src="images/social/google-logo.png"
+              src="/images/social/google-logo.png"
               alt="구글 로그인"
               width="42"
           /></a>
@@ -121,7 +121,7 @@
             rel="noopener noreferrer"
             aria-label="카카오톡 로그인"
             ><img
-              src="images/social/kakao-logo.png"
+              src="/images/social/kakao-logo.png"
               alt="카카오톡 로그인"
               width="42"
           /></a>
@@ -132,6 +132,13 @@
         이미 회원이신가요? <a href="login.html">로그인</a>
       </div>
     </main>
+
+    <div class="popUp-wrapper">
+      <div class="popUp">
+        <p>사용 중인 이메일입니다.</p>
+        <button class="modal-button">확인</button>
+      </div>
+    </div>
   <script src="scripts/signup.js"></script>
   </body>
 </html>

--- a/signup.html
+++ b/signup.html
@@ -121,5 +121,6 @@
         이미 회원이신가요? <a href="login.html">로그인</a>
       </div>
     </main>
+  <script src="scripts/signup.js"></script>
   </body>
 </html>

--- a/styles/auth.css
+++ b/styles/auth.css
@@ -143,6 +143,12 @@
   color: #FFFFFF;
 }
 
+.errorInputBorder {
+  border: 2px solid #F74747;
+  outline-color: #F74747;
+
+}
+
 @media (max-width: 1199px) {
 
 }

--- a/styles/auth.css
+++ b/styles/auth.css
@@ -91,3 +91,21 @@
   /* 밑줄과 텍스트 사이 간격을 조정하고 싶다면 text-underline-offset을 사용하면 돼요. */
   text-underline-offset: 2px;
 }
+
+
+.emailEmpty,
+.emailWrong,
+.pwWrong,
+.pwEmpty,
+.nickEmpty,
+.nickFour,
+.pwCEmpty,
+.pwCWrong {
+  margin-left: 16px;
+  margin-top: 8px;
+
+  display: none;
+  font-size: 15px;
+  font-weight: 600;
+  color: #F74747;
+}

--- a/styles/auth.css
+++ b/styles/auth.css
@@ -83,6 +83,7 @@
   font-weight: 500;
   font-size: 15px;
   text-align: center;
+
 }
 
 .auth-switch a {
@@ -111,6 +112,41 @@
   color: #F74747;
 }
 
+.popUp-wrapper {
+  display: none;
+  top: 0;
+  width: 100%;
+  height: 100%;
+  position: absolute;
+  z-index: 9;
+  background-color: rgba(0,0,0, 0.7);
+}
+
+.popUp {
+  position: absolute;
+  width: 55rem;
+  height: 25rem;
+  font-weight: 500;
+  top: 45%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  background-color: #FFFFFF;
+  border-radius: 8px;
+  text-align: center;
+  padding-top: 10rem;
+  font-size: 16px;
+  z-index: 9999;
+}
+
+.popUp button {
+  background-color: var(--blue);
+  position: absolute;
+  right: 28px;
+  bottom: 28px;
+  padding: 12px 23px;
+  border-radius: 8px;
+  color: #FFFFFF;
+}
 
 @media (max-width: 1199px) {
 
@@ -138,5 +174,11 @@
     width: 200px;
   }
 
+  .popUp {
+    width: 30rem;
+    height: 20rem;
+    padding-top: 5rem;
+    top: 30%;
+  }
 
 }

--- a/styles/auth.css
+++ b/styles/auth.css
@@ -101,7 +101,7 @@
 .nickFour,
 .pwCEmpty,
 .pwCWrong,
-.pwCEight{
+.pwCEight {
   margin-left: 16px;
   margin-top: 8px;
 
@@ -112,15 +112,31 @@
 }
 
 
+@media (max-width: 1199px) {
 
-@media (max-width: 1199px){
-  body{
-    background-color: yellow;
-  }
 }
 
-@media (max-width: 743px){
-  body{
-    background-color: green;
+@media (max-width: 743px) {
+  body {
+    display: flex;
+    justify-content: center;
   }
+  .auth-container {
+    max-width: 400px;
+    display: flex;
+    flex-direction: column;
+
+    margin: 0 14px;
+
+  }
+
+  .logo-home-button-wrapper {
+    margin-top: 48px;
+    margin-bottom: 40px;
+  }
+  .logo-home-button-wrapper img {
+    width: 200px;
+  }
+
+
 }

--- a/styles/auth.css
+++ b/styles/auth.css
@@ -100,7 +100,8 @@
 .nickEmpty,
 .nickFour,
 .pwCEmpty,
-.pwCWrong {
+.pwCWrong,
+.pwCEight{
   margin-left: 16px;
   margin-top: 8px;
 
@@ -108,4 +109,18 @@
   font-size: 15px;
   font-weight: 600;
   color: #F74747;
+}
+
+
+
+@media (max-width: 1199px){
+  body{
+    background-color: yellow;
+  }
+}
+
+@media (max-width: 743px){
+  body{
+    background-color: green;
+  }
 }

--- a/styles/auth.css
+++ b/styles/auth.css
@@ -107,7 +107,7 @@
   color: #F74747;
 }
 
-.popup-wrapper {
+.errorModal {
   display: none;
   top: 0;
   width: 100%;
@@ -115,6 +115,10 @@
   position: absolute;
   z-index: 9;
   background-color: rgba(0,0,0, 0.7);
+}
+
+.showErrorModal {
+  display: block;
 }
 
 .popUp {

--- a/styles/auth.css
+++ b/styles/auth.css
@@ -94,15 +94,10 @@
 }
 
 
-.emailEmpty,
-.emailWrong,
-.pwWrong,
-.pwEmpty,
-.nickEmpty,
-.nickFour,
-.pwCEmpty,
-.pwCWrong,
-.pwCEight {
+#emailError,
+#passwordError,
+#nicknameError,
+#pwConfirmError{
   margin-left: 16px;
   margin-top: 8px;
 
@@ -112,7 +107,7 @@
   color: #F74747;
 }
 
-.popUp-wrapper {
+.popup-wrapper {
   display: none;
   top: 0;
   width: 100%;

--- a/styles/home.css
+++ b/styles/home.css
@@ -61,3 +61,19 @@
   letter-spacing: 0.08em;
   margin-top: 24px;
 }
+
+
+
+
+
+@media (max-width: 1199px){
+  body{
+    background-color: yellow;
+  }
+}
+
+@media (max-width: 743px){
+  body{
+    background-color: green;
+  }
+}

--- a/styles/home.css
+++ b/styles/home.css
@@ -12,6 +12,9 @@
   background-image: url("../images/home/hero-image.png");
 }
 
+.wrapper h1 {
+  width: 400px;
+}
 #features {
   padding-bottom: 138px;
 }
@@ -38,12 +41,13 @@
   gap: 5%;
 }
 
+.feature h1 {
+
+  width: 300px;
+
+}
 .feature:nth-child(2) {
   text-align: right;
-}
-
-.feature-content {
-  flex: 1;
 }
 
 .feature-tag {
@@ -62,15 +66,124 @@
   margin-top: 24px;
 }
 
+.topbanner {
+  display: none;
+}
+
 
 @media (max-width: 1199px) {
-  body {
-    background-color: blue;
+  header {
+    padding: 0 24px;
   }
+  .banner {
+    height: 770px;
+    padding-top: 5rem;
+    align-items: flex-start;
+  }
+  #hero {
+    background-position: center bottom;
+    background-size: 100%;
+    width: 100%;
+  }
+  #hero .wrapper,
+  #bottomBanner .wrapper{
+    text-align: center;
+  }
+
+  .wrapper h1 {
+    width: 100%;
+  }
+
+  #bottomBanner .wrapper {
+    padding-top: 8rem;
+  }
+  #bottomBanner {
+    height: 770px;
+    background-position: center bottom;
+    background-size: 100%;
+    width: 100%;
+    font-size: 40px;
+  }
+
+  .feature {
+    display: flex;
+    flex-direction: column;
+    align-items: stretch;
+    padding: 24px;
+    padding-bottom: 50px;
+  }
+  .feature img {
+    width: 100%;
+  }
+  .feature-content {
+    margin-top: 24px;
+  }
+
+  .feature:nth-child(2) .feature-content{
+    order: 2;
+  }
+
+  footer {
+    padding: 3.2rem 24px 10rem 24px;
+  }
+
 }
 
 @media (max-width: 743px) {
-  body {
-    background-color: green;
+  .banner {
+    height: 540px;
+  }
+
+  #hero .wrapper{
+
+  }
+  #hero .wrapper h1 {
+    margin: 0 auto;
+    font-size: 32px;
+    line-height: 44px;
+  }
+
+  .banner .pill-button {
+    padding: 1.6rem 10rem;
+    margin-top: 1.5rem;
+  }
+
+  #bottomBanner {
+    height: 540px;
+    font-size: 32px;
+  }
+
+  #features {
+    padding: 0;
+  }
+
+  .feature h1 {
+    font-size: 2.5rem;
+    line-height: 4rem;
+  }
+  .feature .feature-description {
+    font-size: 2rem;
+  }
+
+  #footerMenu {
+    grid-area: footerMenu;
+    gap: 1rem;
+    justify-content: flex-start;
+  }
+  #socialMedia {
+    grid-area: socialMedia;
+    justify-self: flex-end;
+  }
+  .copyright {
+    grid-area: copyright;
+    text-align: left;
+  }
+  footer {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    grid-template-areas:
+            "footerMenu socialMedia"
+    "copyright .";
+    gap: 24px;
   }
 }

--- a/styles/home.css
+++ b/styles/home.css
@@ -63,17 +63,14 @@
 }
 
 
-
-
-
-@media (max-width: 1199px){
-  body{
-    background-color: yellow;
+@media (max-width: 1199px) {
+  body {
+    background-color: blue;
   }
 }
 
-@media (max-width: 743px){
-  body{
+@media (max-width: 743px) {
+  body {
     background-color: green;
   }
 }


### PR DESCRIPTION
## 요구사항

### 기본

- [x] 로그인 및 회원가입 페이지의 이메일, 비밀번호, 비밀번호 확인 input에 필요한 유효성 검증 함수를 만들고 적용해 주세요.
- [x] 이메일 input에서 focus out 할 때, 값이 없을 경우 input에 빨강색 테두리와 아래에 “이메일을 입력해주세요.” 빨강색 에러 메세지를 보입니다.
- [x] 이메일 input에서 focus out 할 때, 이메일 형식에 맞지 않는 경우 input에 빨강색 테두리와 아래에 “잘못된 이메일 형식입니다” 빨강색 에러 메세지를 보입니다.
- [x] 비밀번호 input에서 focus out 할 때, 값이 없을 경우 아래에 “비밀번호를 입력해주세요.” 에러 메세지를 보입니다
- [x] 비밀번호 input에서 focus out 할 때, 값이 8자 미만일 경우 아래에 “비밀번호를 8자 이상 입력해주세요.” 에러 메세지를 보입니다.
- [x] input 에 빈 값이 있거나 에러 메세지가 있으면 ‘로그인’ 버튼은 비활성화 됩니다.
- [x] Input 에 유효한 값을 입력하면 ‘로그인' 버튼이 활성화 됩니다.
- [x] 활성화된 ‘로그인’ 버튼을 누르면 “/items” 로 이동합니다
- [x] 이메일과 비밀번호를 입력하고 로그인 버튼을 누른 후, 다음 조건을 참조하여 로그인 성공 여부를 alert 메시지로 출력합니다.
만약 입력한 이메일이 데이터베이스(USER_DATA)에 없거나, 이메일은 일치하지만 비밀번호가 틀린 경우, '비밀번호가 일치하지 않습니다.'라는 메시지를 alert로 표시합니다
만약 입력한 이메일이 데이터베이스에 존재하고, 비밀번호도 일치할 경우, “/items”로 이동합니다.
- [x] 회원가입을 위해 이메일, 닉네임, 비밀번호, 비밀번호 확인을 입력한 뒤, 회원가입 버튼을 클릭하세요. 그 후에는 다음 조건에 따라 회원가입 가능 여부를 alert로 알려주세요.
입력한 이메일이 이미 데이터베이스(USER_DATA)에 존재하는 경우, '사용 중인 이메일입니다'라는 메시지를 alert로 표시합니다.
입력한 이메일이 데이터베이스(USER_DATA)에 없는 경우, 회원가입이 성공적으로 처리되었으므로 로그인 페이지(”/login”)로 이동합니다.

### 심화

- [x] 페이스북, 카카오톡, 디스코드, 트위터 등 SNS에서 판다마켓 랜딩 페이지(“/”) 공유 시 미리보기를 볼 수 있도록 랜딩 페이지 메타 태그를 설정합니다.
- [x] 미리보기에서 제목은 “판다마켓”, 설명은 “일상에서 모든 물건을 거래해보세요”로 설정합니다.
- [x] 주소와 이미지는 자유롭게 설정하세요.
- [x] 로그인, 회원가입 페이지에 공통으로 사용하는 로직이 있다면, 반복하지 않고 공통된 로직을 모듈로 분리해 사용해 주세요.
랜딩 페이지
- [x] 브라우저에 현재 보이는 화면의 영역(viewport) 너비를 기준으로 분기되는 반응형 디자인을 적용합니다.
PC: 1200px 이상
Tablet: 744px 이상 ~ 1199px 이하
Mobile: 375px 이상 ~ 743px 이하
375px 미만 사이즈의 디자인은 고려하지 않습니다
- [x] Tablet 사이즈로 작아질 때 최소 좌우 여백이 “판다마켓” 로고의 왼쪽에 여백 24px, “로그인” 버튼 오른쪽 여백 24px을 유지할 수 있도록 “판다마켓” 로고와 “로그인" 버튼의 간격이 가까워집니다.
- [x] Mobile 사이즈로 작아질 때 최소 좌우 여백이 “판다마켓” 로고의 왼쪽에 여백 16px, “로그인” 버튼 오른쪽 여백 16px을 유지할 수 있도록 “판다마켓” 로고와 “로그인" 버튼의 간격이 가까워집니다.
- [x] PC, Tablet 사이즈의 이미지 크기는 고정값을 사용합니다.
- [x] Mobile 사이즈의 이미지는 좌우 여백 32px을 제외하고 이미지 영역이 꽉 차게 구현합니다. (이때 가로가 커지는 비율에 맞춰 세로도 커져야 합니다.)
- [x] Mobile 사이즈 너비가 커지면, “Privacy Policy”, “FAQ”, “codeit-2023”이 있는 영역과 SNS 아이콘들이 있는 영역의 사이 간격이 커집니다.
- [x] Tablet 사이즈에서 내부 디자인은 PC사이즈와 동일합니다.
- [x] Mobile 사이즈에서 좌우 여백 16px 제외하고 내부 요소들이 너비를 모두 차지합니다.
- [x] Mobile 사이즈에서 내부 요소들의 너비는 기기의 너비가 커지는 만큼 커지지만 400px을 넘지 않습니다.
- [x] 오류 메시지 모달을 구현합니다. 모달 내 내용은 alert 메시지와 동일합니다.
- [x] 비밀번호 및 비밀번호 확인 입력란에 눈 모양 아이콘 클릭 시 비밀번호 표시/숨기기 토글이 가능합니다. 기본 상태는 비밀번호 숨김으로 설정합니다.

## 주요 변경사항

-
-

## 스크린샷

![Screenshot from 2024-12-23 11-29-15](https://github.com/user-attachments/assets/db4f6813-3014-41d5-ab53-38349ef59d42)
![Screenshot from 2024-12-23 11-29-29](https://github.com/user-attachments/assets/52e46602-45de-4f9e-bf94-e3f1d3a3ef7b)
![Screenshot from 2024-12-23 11-29-39](https://github.com/user-attachments/assets/90fbb3d9-9919-4819-b087-1c6f7399cecf)


## 멘토에게

- 돌아가는 코드, 작동되는 코드가 좋은 코드인 것임에는 이견이 없지만.. 어떤 코드가 가독성 좋은 코드인지, 유지보수에 용이한 코드인지 모르겠습니다..
- 고수가 되고싶습니다.