### PR TITLE
[김희성] sprint 3

### DIFF
--- a/index.HTML
+++ b/index.HTML
@@ -3,8 +3,13 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <link rel="stylesheet" href="index.css">
+  <!-- Open Graph메타 태그 : 미리보기 화면 구성-->
+  <meta property="og:title" content="판다마켓">
+  <meta property="og:description" content="일상에서 모든 물건을 거래해보세요">
+  <meta property="og:image" content="판다 얼굴.png">
+  <meta property="og:url" content="https://yourwebsite.com">
   <title>판다 마켓</title>
+  <link rel="stylesheet" href="index.css">
   <link rel="stylesheet" as="style" crossorigin href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/static/pretendard.min.css" />
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-VQZH032T95"></script>
 <script>
@@ -20,26 +25,25 @@
 
     <div class="head-log">
       <div class="head-main-img">
-  <img class="head-img1" src="판다 얼굴.png">
-  <a class="head-img2" href="./index.HTML">
+  <img class="head-log-img" src="판다 얼굴.png">
+  <a class="head-text-img" href="./index.html">
   <img src="판다마켓.png">
 </a>
 </div>
-  <a class="head-button" href="./login.html">로그인</a>
+  <a class="login-button" href="./login.html">로그인</a>
 </div>
-
  </header>
 
- <main class="container">
-<div class="watch-containor">
- <div class="watch-content">
-<div class="watch-textbox">
-  <h1 class="watch-main-text">일상의 모든 물건을<br/>
+ <main class="containor">
+<div class="look-containor">
+ <div class="look-content">
+<div class="look-textbox">
+  <h1 class="look-main-text">일상의 모든 물건을<br/>
     거래해 보세요</h1>
-  <a class="watch-button" href="./items.html">구경하러 가기</a>
+  <a class="look-button" href="./items.html">구경하러 가기</a>
 </div>
-<div class="watch-img-box">
-<img class="watch-img" src="Group 33680.png">
+<div class="look-img-box">
+<img class="look-img" src="Group 33680.png">
 </div>
  </div>
 </div>
@@ -105,7 +109,6 @@
 
  <footer class="footer-containor">
   <div class="footer-content">
-
     <div>
   <a class="footer-source">©codeit - 2024</a>
 </div>

--- a/index.css
+++ b/index.css
@@ -32,81 +32,61 @@ header {
   position: fixed;
   display: flex;
   justify-content: center;
+  align-items: center;
   width: 100%;
   height: 7rem;
-  padding: 1rem 20rem;
+  padding: 0 24px;
   z-index: 10;
   background-color: var(--headerbackgroundcolor);
 }
 
-
 .head-log {
-  position: relative;
-  text-align: center;
-  font-size: 1.6rem;
   display: flex;
   justify-content: space-between;
   align-items: center;
   width: 100%;
-  gap: 2rem;
   max-width: 112rem;
 }
 
-.head-main-img{
+.head-main-img {
   display: flex;
   align-items: center;
-  justify-content: flex-start;
-  width:: 100%;
-  height: auto;
-  flex-shrink: 0;
   gap: 8.59px;
 }
 
-.head-img1 {
+.head-log-img {
   width: auto;
   height: 4rem;
-  flex-shrink: 0;
 }
 
-.head-img2 > img {
+.head-text-img > img {
   width: auto;
   height: 2rem;
-  flex-shrink: 0;
-  display: flex;
-  align-items: center;
 }
 
-.head-button {
-  position: relative;
-  display: block;
+.login-button {
   padding: 1rem 4.3rem;
   border-radius: 0.8rem;
   background-color: var(--buttoncolor);
   font-size: 1.6rem;
   font-weight: 600;
   color: var(--buttontextcolor);
-  white-space: nowrap;
   text-decoration: none;
   text-align: center;
-  flex-shrink: 0;
 }
 
-.head-button:hover {
+.login-button:hover {
   cursor: pointer;
 }
 
-.container {
+.containor {
   width: 100%;
-  height: 100%;
   display: flex;
   flex-direction: column;
-  justify-content: center;
   align-items: center;
 }
 
-
-.watch-containor {
-  position: relative;
+.look-containor {
   width: 100%;
   height: 54rem;
   background-color: var(--watchlastbackcolor);
@@ -115,33 +95,27 @@ header {
   justify-content: center;
 }
 
-.watch-content {
-  position: relative;
+.look-content {
   display: flex;
   align-items: center;
-  justify-content: center;
-  height: auto;
-  gap: 2rem; 
+  gap: 2rem;
   flex-wrap: wrap;
 }
 
-.watch-textbox {
-  height: auto;
-  flex-wrap: nowrap;
-  white-space: nowrap;
+.look-textbox {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
 }
 
-.watch-main-text {
+.look-main-text {
   font-size: 3rem;
   font-weight: 700;
   line-height: 1.4;
-  text-align: left;
 }
 
-.watch-button {
-  display: flex;
-  align-items: center;
-  justify-content: center;
+.look-button {
+  display: inline-block;
   padding: 1.2rem 12.4rem;
   border-radius: 3rem;
   background-color: var(--buttoncolor);
@@ -149,225 +123,190 @@ header {
   font-weight: 600;
   color: var(--buttontextcolor);
   text-align: center;
+  text-decoration: none;
   white-space: nowrap;
   margin-top: 2rem;
-  text-decoration: none;
-  width: 100%;
 }
 
-a.watch-button:hover {
+.look-button:hover {
   cursor: pointer;
 }
 
-.watch-img-box{
- display: flex;
- justify-content: center;
+.look-img-box {
+  display: flex;
+  justify-content: center;
 }
 
-.watch-img {
-  width: 90%;
+.look-img {
+  width: 100%;
   max-width: 746px;
-  height: auto;
-  object-fit: contain;
 }
 
 .explain-containor {
   display: flex;
   flex-direction: column;
   align-items: center;
-  justify-content: center;
-  text-align: center;
-  font-size: 1.6rem;
-  padding: 138px 0;
   gap: 276px;
+  padding: 138px 0;
 }
 
-
-.explain-content, .explain-content1{
-  position: relative;
+.explain-content,
+.explain-content1 {
   display: flex;
-  justify-content: center;
   align-items: center;
-  height: auto;
-  font-size: 0;
   gap: 2%;
   background-color: var(--explainbackcolor);
-  white-space: nowrap;
-  flex-wrap: nowrap;
   padding: 0;
 }
 
-  .explain-content1 {
-    justify-content: flex-end;
-  }
+.explain-box {
+  display: flex;
+  flex-direction: column;
+  white-space: nowrap;
+  padding: 3rem;
+  flex: 1;
+}
 
- .explain-content1 > div p {
-   text-align: right;
- }
-
- .explain-box{
-    height: auto;
-    flex-wrap: nowrap;
-    white-space: nowrap;
- }
-
- .explain-title-text {
+.explain-title-text {
   font-size: 1rem;
   font-weight: 700;
-  line-height: 2.6;
   color: var(--buttoncolor);
-  text-align: left;
-  }
+}
 
 .explain-main-text {
   font-size: 3rem;
   font-weight: 700;
   line-height: 1.4;
-  text-align: left;
 }
 
 .explain-sub-text {
   font-size: 2rem;
   font-weight: 500;
   line-height: 1.4;
-  text-align: left;
 }
 
 .explain-img-box {
-    display: flex;
-    justify-content: center;
+  display: flex;
+  justify-content: center;
 }
 
 .explain-img {
   width: 100%;
-  max-width : 588px;
-  height: auto;
-  white-space: nowrap;
-  }
+  max-width: 588px;
+}
 
 .last-containor {
-  position: relative;
   width: 100%;
   height: 54rem;
   display: flex;
   align-items: flex-end;
   justify-content: center;
   background-color: var(--watchlastbackcolor);
-  margin-top: 13.8rem;
 }
 
 .last-content {
-  position: relative;
   display: flex;
   align-items: center;
-  justify-content: center;
-  height: auto;
-  gap: 69px; 
+  gap: 69px;
   flex-wrap: wrap;
-  }
-
-.last-text-box {
-  position: relative;
-  height: auto;
-  flex-wrap: nowrap;
-  white-space: nowrap;
 }
 
-  .last-title-text {
-  display: flex;
-  align-items: center;
-  justify-content: flex-start;
+.last-text-box {
+  flex: 1;
+}
+
+.last-title-text {
   font-size: 3rem;
   font-weight: 700;
   line-height: 1.4;
-  text-align: left;
-  white-space: nowrap;
-  }
+}
 
-  .last-img-box  {
-    position: relative;
-    display: flex;
-   }
+.last-img-box {
+  display: flex;
+}
 
-  .last-img {
-    width: 90%;
-    max-width: 746px;
-    height: auto;
-    object-fit: contain;
-  }
-
+.last-img {
+  width: 90%;
+  max-width: 746px;
+}
 
 .footer-containor {
-  position: relative;
   background-color: var(--footerbackcolor);
-  height: auto;
-  font-size: 1.6rem;
   padding: 3.2rem 2rem;
   display: flex;
   justify-content: center;
-  align-items: center;
-  flex-wrap: nowrap;
 }
-
 
 .footer-content {
   width: 90%;
   display: flex;
-  height: auto;
-  align-items: center;
   justify-content: space-between;
-  padding: 0;
+  flex-wrap: nowrap;
 }
 
 .footer-source {
-  flex-shrink: 0;
   font-size: 1.6rem;
   font-weight: 400;
-  line-height: 1.909;
-  text-align: center;
   color: var(--footersourcecolor);
-  white-space: nowrap;
-  flex-grow: 1;
-  justify-content: center;
 }
 
 .footer-button {
-  font-size: 1.6rem;
-  font-weight: 400;
-  line-height: 1.909;
-  text-align: center;
-  white-space: nowrap;
-  color: var(--footerbuttoncolor);
   display: flex;
   gap: 2rem;
-  flex-grow: 1;
-  justify-content: center;
+  font-size: 1.6rem;
+  color: var(--footerbuttoncolor);
 }
 
-.footer-button:hover {
-  cursor: pointer;
-  text-decoration-line: none;
+.footer-button a {
+  text-decoration: none;
 }
 
-.footer-button > a {
-  right: 0;
-  margin-left: 30px;
-}
-  
 .footer-sub-img {
-  width:: 100%;
-  height: auto;
-  flex-shrink: 0;
   display: flex;
-  gap: 1rem;
-  margin-left: 2rem;
+  gap: 0.7rem;
 }
 
-.footer-sub-img > a img {
-  width: 17px;
-  height: 1.7;
+.footer-sub-img img {
+  width: 16px;
+  height: auto;
 }
 
-.footer-sub-img:hover > a img {
-  cursor: pointer;
+@media (max-width: 1199px) {
+  header {
+    padding: 0 24px;
+  }
+  .head-main-img {
+    gap: 16px;
+  }
+  .watch-content {
+    flex-direction: column;
+    align-items: center;
+  }
+  .explain-content {
+    flex-direction: column;
+    align-items: center;
+  }
+  .explain-content1 {
+    flex-direction: column;
+    align-items: center;
+  }
+}
+
+@media (max-width: 743px) {
+  header {
+    padding: 0 16px;
+  }
+  .watch-content {
+    flex-direction: column;
+  }
+  .watch-button {
+    width: calc(100% - 32px);
+  }
+  .watch-img {
+    max-width: 400px;
+  }
+  .footer-content {
+    white-space: nowrap;
+    gap: 2rem;
+  }
 }

--- a/login.css
+++ b/login.css
@@ -20,7 +20,7 @@ display: flex;
 justify-content: center;
 }
 
-main  {
+form  {
   width: 100%;
 }
 
@@ -52,7 +52,7 @@ align-items: center;
   gap: 5%;
 }
 
-.head-img1 {
+.logo-img {
   width: 103.53px;
   max-width: 20%;
   height: auto;
@@ -60,11 +60,26 @@ align-items: center;
 
 }
 
-.head-img2 {
+.logo-text-img {
   width: 80%;
   max-width: 266px;
   height: auto;
   max-height: 90px;
+}
+
+.error-message-container {
+  margin-top: 8px; 
+}
+
+.error-message {
+  color: #F74747; 
+  font-size: 14px;
+  font-weight: 600;
+  margin: 0;
+}
+
+#mail-content {
+  padding-bottom: 24px;
 }
 
 .mail-containor {
@@ -72,7 +87,6 @@ align-items: center;
  flex-direction: column;
  width: 100%;
  max-width: 640px;
- margin-bottom: 24px;
 }
 
 .mail-title-text {
@@ -116,6 +130,10 @@ background-color:var(--inputextbackgroundcolor);
   border-color: var(--inputfocuscolor);
 }
 
+#password-content {
+  padding-bottom: 24px;
+}
+
 .pass-title-text {
   width: 63px;
   height: 26px;
@@ -144,17 +162,20 @@ background-color:var(--inputextbackgroundcolor);
   border-color: var(--inputfocuscolor);
 }
 
-.pass-containor > a img{
+#togglePassword {
+  cursor : pointer;
+}
+
+.password-icon {
   position: absolute;
   width: 24px;
   height: 24px;
   top: 18px;
   bottom: 50px;
   right: 20px;
-}
-
-.passcontainor a:hover {
-  
+  background: url(btn_visibility_on_24px.png);
+  background-size: cover;
+  background-repeat: no-repeat;
 }
 
 .login-button {
@@ -164,7 +185,9 @@ align-items: center;
 width: 100%;
 height: 56px;
 padding: 16px 124px 16px 124px;
-margin: 24px 0;
+font-size: 20px;
+font-weight: 600;
+margin-bottom: 24px; 
 gap: 10px;
 border-radius: 40px;
 opacity: 0px;
@@ -172,6 +195,7 @@ color:var(--inputextbackgroundcolor);
 white-space: nowrap;
 text-decoration: none;
 text-align: center;
+border: none;
 flex-shrink: 0;
 background-color: var(--inputtextcolor);
 }
@@ -180,7 +204,6 @@ background-color: var(--inputtextcolor);
 .login-button:hover {
   cursor: pointer;
   background-color:var(--inputfocuscolor);
-  ;
 }
 
 .easylogin-cotainor {
@@ -219,4 +242,69 @@ text-decoration-skip-ink: none;
   display: flex;
   justify-content: center;
   gap: 0.3rem;
+}
+
+.modal-hidden {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 1000;
+  /* visibility : 가시성 hidden : 숨기기 */
+  visibility: hidden;
+  /* transition 애니메이션 효과 적용 */
+  transition: opacity 0.3s ease, visibility 0.3s ease;
+}
+
+#modal-message {
+  position: relative;
+}
+
+.modal-content {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  background-color: white;
+  padding: 20px 30px;
+  border-radius: 8px;
+  text-align: center;
+  width: 90%;
+  max-width: 540px;
+  min-height: 250px;
+}
+
+.modal-content p {
+  font-size: 16px;
+  color: #1F2937;
+  margin-bottom: 20px;
+}
+
+.modal-btn {
+  position: absolute;
+  background-color: var(--inputfocuscolor);
+  color: var(--inputextbackgroundcolor);
+  border: none;
+  width: 120px;
+  height: 48px;
+  padding: 10px 20px;
+  right: 28px;
+  bottom: 28px;
+  border-radius: 14px;
+  cursor: pointer;
+  transition: background 0.2s ease;
+}
+
+.modal-button:hover {
+  background: var(--inputfocuscolor);
+}
+
+.show {
+  opacity: 1;
+  visibility: visible;
 }

--- a/login.html
+++ b/login.html
@@ -21,28 +21,32 @@
   <div class="containor">
   <header class="header-containor">
     <div class="head-content">
-    <img class="head-img1" src="판다 얼굴.png">
-    <a  href="./index.HTML">
-    <img class="head-img2" src="판다마켓.png">
+    <img class="logo-img" src="판다 얼굴.png">
+    <a  href="./index.html">
+    <img class="logo-text-img" src="판다마켓.png">
   </div>
 </header>
   
-<main>
+<form>
+  <div id="mail-content">
   <div class="mail-containor">
 <a class="mail-title-text">이메일</a>
- <input class="main-insert-text" type="email" placeholder="이메일을 입력해주세요" />
+ <input id="email-Input" class="main-insert-text" type="email" placeholder="이메일을 입력해주세요" />
+</div>
+<div class="error-message-container"></div> 
 </div>
 
-<div>
+<div id="password-content">
 <h2 class="pass-title-text">비밀번호<h2>
 <div class="pass-containor">
-  <input class="main-insert-text" type="password" placeholder="비밀번호를 입력해주세요" />
-  <a><img src="btn_visibility_on_24px.png"></a>
+  <input id="password-Input" class="main-insert-text" type="password" placeholder="비밀번호를 입력해주세요" />
+  <img id="togglePassword" class="password-icon" src="./btn_visibility_on_24px.png">
 </div>
+<div class="error-message-container"></div> 
 </div>
 
 <div>
-<a class="login-button">로그인</a>
+<button class="login-button">로그인</button>
 </div>
 
 <div class="easylogin-cotainor">
@@ -56,14 +60,23 @@
   <img class="easylogin-img" src="Component 3.png">
 </a>
   </div>
-</div>
+ </div>
 </div>
 
 <div class="signup-cotainor">
 <a>판다마켓이 처음이신가요?</a>
 <a href="./signup.html">회원가입</a>
    </div>
-  </main>
+  </form>
+
+  <div id="error-modal" class="modal-hidden">
+    <div class="modal-content">
+      <p id="modal-message">비밀번호가 일치하지 않습니다.</p>
+      <button id="modal-closeBtn" class="modal-btn">확인</button>
+    </div>
+  </div>
+
 </div>
+<script src="login.js"></script>
  </body>
 </html>

--- a/login.js
+++ b/login.js
@@ -1,0 +1,190 @@
+// errortext.color = "#F74747";
+// input focusout시 border-color  "#F74747";
+/*이메일 input에서 focus out 할 때, 값이 없을 경우 input에 빨강색 테두리와 아래에 “이메일을 입력해주세요.” 빨강색 에러 메세지를 보입니다.
+이메일 input에서 focus out 할 때, 이메일 형식에 맞지 않는 경우 input에 빨강색 테두리와 아래에 “잘못된 이메일 형식입니다” 빨강색 에러 메세지를 보입니다.
+비밀번호 input에서 focus out 할 때, 값이 없을 경우 아래에 “비밀번호를 입력해주세요.” 에러 메세지를 보입니다
+비밀번호 input에서 focus out 할 때, 값이 8자 미만일 경우 아래에 “비밀번호를 8자 이상 입력해주세요.” 에러 메세지를 보입니다. */
+// error text
+// email = "이메일을 입력해주세요" , 형식이 틀릴 경우 = "잘못된 이메일 형식입니다."
+// passward = "비밀번호를 입력해주세요." , 8자이하 "비밀번호를 8자 이상 입력해주세요."
+//  로그인 및 회원가입 페이지의 이메일, 비밀번호, 비밀번호 확인 input에 필요한 유효성 검증 함수를 만들고 적용해 주세요
+document.addEventListener("DOMContentLoaded", () => {
+const emailInput = document.querySelector("#email-Input");
+const passwordInput = document.querySelector("#password-Input");
+const togglePassword = document.querySelector("#togglePassword");
+const loginBtn = document.querySelector(".login-button");
+
+const USER_DATA = [
+           { email: 'codeit1@codeit.com', password: "codeit101!" },
+	         { email: 'codeit2@codeit.com', password: "codeit202!" },
+           { email: 'codeit3@codeit.com', password: "codeit303!" },
+           { email: 'codeit4@codeit.com', password: "codeit404!" },
+ 	         { email: 'codeit5@codeit.com', password: "codeit505!" },
+           { email: 'codeit6@codeit.com', password: "codeit606!" },
+]
+
+//에러 메세지 생성
+const createErrorMessage = (input, message) => {
+  removeErrorMessage(input);
+  //Element : 엘리먼트를 추상화한 객체
+  const errorContainer = input.parentElement.nextElementSibling;
+  const errorElement = document.createElement("div");
+  errorElement.className = "error-message";
+  errorElement.textContent = message;
+  errorElement.style.color = "#F74747" ;
+  input.style.borderColor = "#F74747" ;
+  input.classList.add("error");
+  errorContainer.appendChild(errorElement);
+};
+
+const removeErrorMessage = (input) => {
+  input.classList.remove("error");
+  input.style.borderColor = "";
+  const errorContainer = input.parentElement.nextElementSibling;
+  errorContainer.innerHTML = "";
+};
+
+let startLoad = true;
+
+const validateEmail = () => {
+  //emailinput에 들어가는 볼륨 확인
+  //trim() 양끝 공백 제거
+  const emailValue = emailInput.value.trim();
+  const emailxp = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+  if (startLoad) return true;
+
+   if (!emailValue) {
+    createErrorMessage(emailInput, "이메일을 입력해주세요.");
+    return false;
+    //test() : 패턴이 일치하는지 확인하는 불리언 반환 매서드
+  } else if (!emailxp.test(emailValue)){
+    createErrorMessage(emailInput, "잘못된 이메일 형식입니다.");
+    return false;
+  } else {
+    removeErrorMessage(emailInput);
+    return true;
+  }
+};
+
+const validatePassword  = () => {
+  const passwordValue = passwordInput.value.trim();
+
+  if (startLoad) return true;
+
+  if (!passwordValue) {
+    createErrorMessage(passwordInput, "비밀번호를 입력해주세요.");
+    return false;
+  } else if (passwordValue.length < 8) {
+    createErrorMessage(passwordInput, "비밀번호를 8자 이상 입력해주세요.");
+    return false;
+  } else {
+    removeErrorMessage(passwordInput);
+    return true;
+  }
+};
+
+// input에 빈 값 or errorm messege 있으면 로그인 버튼 비활성화
+// input에 유효값이 있다면 로그인 버튼 활성화
+// 활성화 된 로그인 버튼은 아이템으로 이동
+
+const disableSignupButton = () => {
+  loginBtn.style.backgroundColor = "var(--inputtextcolor)";
+  loginBtn.style.pointerEvents = "none";
+  loginBtn.style.cursor = "not-allowed";
+  loginBtn.setAttribute("disabled", "true");
+};
+
+disableSignupButton();
+
+const toggleLoginBtn = () => {
+  loginBtn.setAttribute("disabled", "true");
+  if(startLoad) return false;
+
+    if (validateEmail() && validatePassword()) {
+    loginBtn.style.backgroundColor = "var(--inputfocuscolor)";
+    loginBtn.style.pointerEvents = "";
+    // cursor가 pointer(link)를 나타낸다.
+    loginBtn.style.cursor = "pointer";
+    //Attribute : 모든 속성값을 읽음
+    //disabled : 값이 true면 비활성화, false면 활성화
+    loginBtn.removeAttribute("disabled", "false");
+  } else {
+    disableSignupButton();
+  }
+};
+
+// 눈모양 아이콘 비밀번호 표시/ 숨기기 토글 = 기본상태는 숨김
+togglePassword.addEventListener("click", () => {
+if (passwordInput.type === "password"){
+  passwordInput.type = "text";
+} else {
+  passwordInput.type = "password";
+}
+});
+
+//이벤트 발생
+emailInput.addEventListener ("blur", () => {
+  startLoad = false;
+  validateEmail();
+  toggleLoginBtn();
+});
+emailInput.addEventListener ("input", () => {
+  removeErrorMessage(emailInput);
+  toggleLoginBtn();
+});
+
+
+passwordInput.addEventListener ("blur", () => {
+  startLoad = false;
+  validatePassword();
+  toggleLoginBtn();
+});
+passwordInput.addEventListener ("input", () => {
+  removeErrorMessage(passwordInput);
+  toggleLoginBtn();
+});
+
+
+// 이메일이 데이터베이스에 없거나 이메일은 일치하지만 비밀번호가 틀린경우 "비밀번호가 일치하지 않습니다." alert messege 표시
+// 오류 메시지 모달을 구현합니다. 모달 내 내용은 alert 메시지와 동일합니다.
+// (비밀번호가 일치하지 않습니다.)
+const showModal = (message) => {
+  const modal = document.querySelector("#error-modal");
+  const modalMessage = document.querySelector("#modal-message");
+  modalMessage.textContent = message;
+  modal.classList.add("show");
+};
+
+const closeModal = () => {
+  const modal = document.querySelector("#error-modal");
+  modal.classList.remove("show")
+};
+
+document.querySelector("#modal-closeBtn").addEventListener("click", closeModal);
+
+loginBtn.addEventListener("click", (e) => {
+  // 페이지 새로고침 방지
+  e.preventDefault();
+
+  const emailValue = emailInput.value.trim();
+  const passwordValue = passwordInput.value.trim();
+  //find : 배열에서 특정 조건을 만족하는 요소를 찾아 첫 번째 요소로 반환
+  const user = USER_DATA.find((user) => user.email === emailValue);
+
+    if (!user){
+      showModal("비밀번호가 일치하지 않습니다.");
+    } else if (user.password !== passwordValue) {
+      showModal("비밀번호가 일치하지 않습니다.");
+    } else {
+      window.location.href = "./items.html";
+    }
+
+});
+
+toggleLoginBtn();
+});
+
+
+
+

--- a/signup.css
+++ b/signup.css
@@ -20,7 +20,7 @@ body {
   justify-content: center;
 }
 
-main  {
+form  {
   width: 100%;
 }
 
@@ -53,7 +53,7 @@ main  {
   gap: 5%;
 }
 
-.head-img1 {
+.logo-img {
   width: 103.53px;
   max-width: 20%;
   height: auto;
@@ -61,22 +61,36 @@ main  {
 
 }
 
-.head-img2 {
+.logo-text-img {
   width: 80%;
   max-width: 266px;
   height: auto;
   max-height: 90px;
 }
 
-.main-containor {
- display: flex;
- flex-direction: column;
- width: 100%;
- max-width: 640px;
- margin-bottom: 24px;
+.error-message-container {
+  margin-top: 8px; 
 }
 
-.main-title-text {
+.error-message {
+  color: #F74747; 
+  font-size: 14px;
+  font-weight: 600;
+  margin: 0;
+}
+
+#mail-content {
+  padding-bottom: 24px;
+}
+
+.mail-containor {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  max-width: 640px;
+ }
+
+ .mail-title-text {
   width: 47px;
   height: 26px;
   font-size: 18px;
@@ -89,35 +103,61 @@ main  {
   margin-bottom: 16px;
 }
 
-.main-input-text {
-width: 100%;
-height: 56px;
-padding: 16px 24px 16px 24px;
-gap: 10px;
-border-radius: 12px;
-opacity: 0px;
-font-size: 16px;
-font-weight: 400;
-line-height: 26px;
-color: var(--inputtextcolor);
-text-align: left;
-text-underline-position: from-font;
-text-decoration-skip-ink: none;
-border-width: 0;
-background-color:var(--inputextbackgroundcolor);
-}
-
-
-.main-input-text:focus {
+.main-insert-text {
+  width: 100%;
+  height: 56px;
+  padding: 16px 24px 16px 24px;
+  gap: 10px;
+  border-radius: 12px;
+  opacity: 0px;
   font-size: 16px;
   font-weight: 400;
-  color: var(--maintextcolor);
-  width: 100%;
-  outline: none;
-  border: 1px solid;
-  border-color: var(--inputfocuscolor);
+  line-height: 26px;
+  color: var(--inputtextcolor);
+  text-align: left;
+  text-underline-position: from-font;
+  text-decoration-skip-ink: none;
+  border: none;
+  background-color:var(--inputextbackgroundcolor);
+  }
+
+  .main-insert-text:focus {
+    font-size: 16px;
+    font-weight: 400;
+    color:var(--maintextcolor);
+    width: 100%;
+    outline: none;
+    border: 1px solid;
+    border-color: var(--inputfocuscolor);
+  }
+
+  #name-content {
+    padding-bottom: 24px;
+  }
+
+.name-containor {
+ display: flex;
+ flex-direction: column;
+ width: 100%;
+ max-width: 640px;
 }
 
+.name-title-text {
+  width: 47px;
+  height: 26px;
+  font-size: 18px;
+  font-weight: 700;
+  color: var(--maintextcolor);
+  gap: 0px;
+  opacity: 0px;
+  white-space: nowrap;
+  text-decoration: none;
+  margin-bottom: 16px;
+}
+
+#password-content {
+  padding-bottom: 24px;
+}
 
 .pass-title-text {
   width: 63px;
@@ -137,9 +177,6 @@ background-color:var(--inputextbackgroundcolor);
   height: 56px;
   position: relative;
   display: flex;
-  background-color: var(--inputextbackgroundcolor);
-  margin-bottom: 24px;
-  border-radius: 12px;
 }
 
 .pass-containor input:focus{
@@ -150,56 +187,38 @@ background-color:var(--inputextbackgroundcolor);
   border-color: var(--inputfocuscolor);
 }
 
-.pass-containor > a img{
+#togglePassword {
+  cursor : pointer;
+}
+
+.password-icon {
   position: absolute;
   width: 24px;
   height: 24px;
   top: 18px;
   bottom: 50px;
   right: 20px;
-  
+  background: url(btn_visibility_on_24px.png);
+  background-size: cover;
+  background-repeat: no-repeat;
 }
 
-.passcontainor a:hover {
-  
+
+#togglePassword {
+  cursor : pointer;
 }
 
-.pass-input-text {
-  width: 80%;
-  height: 56px;
-  padding: 16px 24px 16px 24px;
-  gap: 10px;
-  border-radius: 12px;
-  opacity: 0px;
-  font-size: 16px;
-  font-weight: 400;
-  line-height: 26px;
-  color: var(--inputtextcolor);
-  text-align: left;
-  text-underline-position: from-font;
-  text-decoration-skip-ink: none;
-  border-width: 0;
-  background-color:var(--inputextbackgroundcolor)
+.password-icon {
+  position: absolute;
+  width: 24px;
+  height: 24px;
+  top: 18px;
+  bottom: 50px;
+  right: 20px;
+  background: url(btn_visibility_on_24px.png);
+  background-size: cover;
+  background-repeat: no-repeat;
 }
-
-.repass-input-text {
-  width: 90%;
-  height: 56px;
-  padding: 16px 24px 16px 24px;
-  gap: 10px;
-  border-radius: 12px;
-  opacity: 0px;
-  font-size: 0.85rem;
-  font-weight: 400;
-  line-height: 26px;
-  color: var(--inputtextcolor);
-  text-align: left;
-  text-underline-position: from-font;
-  text-decoration-skip-ink: none;
-  border-width: 0;
-  background-color:var(--inputextbackgroundcolor);
-}
-
 
 .signup-button {
   display: flex;
@@ -209,6 +228,8 @@ background-color:var(--inputextbackgroundcolor);
   height: 56px;
   padding: 16px 124px 16px 124px;
   margin-bottom: 24px;
+  font-size: 20px;
+  font-weight: 600;
   gap: 10px;
   border-radius: 40px;
   opacity: 0px;
@@ -216,6 +237,7 @@ background-color:var(--inputextbackgroundcolor);
   white-space: nowrap;
   text-decoration: none;
   text-align: center;
+  border: none;
   flex-shrink: 0;
   background-color: var(--inputtextcolor);
   }
@@ -258,4 +280,69 @@ text-decoration-skip-ink: none;
   display: flex;
   justify-content: center;
   gap: 0.3rem;
+}
+
+.modal-hidden {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 1000;
+  /* visibility : 가시성 hidden : 숨기기 */
+  visibility: hidden;
+  /* transition 애니메이션 효과 적용 */
+  transition: opacity 0.3s ease, visibility 0.3s ease;
+}
+
+#modal-message {
+  position: relative;
+}
+
+.modal-content {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  background-color: white;
+  padding: 20px 30px;
+  border-radius: 8px;
+  text-align: center;
+  width: 90%;
+  max-width: 540px;
+  min-height: 250px;
+}
+
+.modal-content p {
+  font-size: 16px;
+  color: #1F2937;
+  margin-bottom: 20px;
+}
+
+.modal-btn {
+  position: absolute;
+  background-color: var(--inputfocuscolor);
+  color: var(--inputextbackgroundcolor);
+  border: none;
+  width: 120px;
+  height: 48px;
+  padding: 10px 20px;
+  right: 28px;
+  bottom: 28px;
+  border-radius: 14px;
+  cursor: pointer;
+  transition: background 0.2s ease;
+}
+
+.modal-button:hover {
+  background: var(--inputfocuscolor);
+}
+
+.show {
+  opacity: 1;
+  visibility: visible;
 }

--- a/signup.html
+++ b/signup.html
@@ -16,50 +16,59 @@
   <title>회원가입 페이지</title>
 </head>
 <body>
+
   <div class="containor">
   <header class="header-containor">
     <div class="head-content">
-    <img class="head-img1" src="판다 얼굴.png">
-    <a href="./index.HTML">
-    <img class="head-img2" src="판다마켓.png">
+    <img class="logo-img" src="판다 얼굴.png">
+    <a href="./index.html">
+    <img class="logo-text-img" src="판다마켓.png">
   </div>
 </header>
   
-<main>
-  <div class="main-containor">
-<a class="main-title-text">이메일</a>
- <input class="main-input-text" type="email" placeholder="이메일을 입력해주세요" />
-</div>
-
-<div class="main-containor">
-  <a class="main-title-text">닉네임</a>
-   <input class="main-input-text" type="text" placeholder="닉네임을 입력해주세요" />
+<form>
+  <div id="mail-content">
+    <div class="mail-containor">
+  <a class="mail-title-text">이메일</a>
+   <input id="email-Input" class="main-insert-text" type="email" placeholder="이메일을 입력해주세요" />
+  </div>
+  <div class="error-message-container"></div> 
   </div>
 
-<div>
-<h2 class="pass-title-text">비밀번호<h2>
-<div class="pass-containor">
-  <input class="pass-input-text" type="password" placeholder="비밀번호를 입력해주세요" />
-  <a><img src="btn_visibility_on_24px.png"></a>
-</div>
-</div>
+  <div id="name-content">
+<div class="name-containor">
+  <a class="name-title-text">닉네임</a>
+   <input id="name-Input" class="main-insert-text" type="text" placeholder="닉네임을 입력해주세요" />
+  </div>
+  <div class="error-message-container"></div> 
+  </div>
 
-<div>
+  <div id="password-content">
+    <h2 class="pass-title-text">비밀번호<h2>
+    <div class="pass-containor">
+      <input id="password-Input" class="main-insert-text" type="password" placeholder="비밀번호를 입력해주세요" />
+      <img id="togglePassword" class="password-icon" src="./btn_visibility_on_24px.png">
+    </div>
+    <div class="error-message-container"></div> 
+    </div>
+
+<div id="password-content">
   <h2 class="pass-title-text">비밀번호 확인<h2>
   <div class="pass-containor">
-    <input class="repass-input-text" type="password" placeholder="비밀번호를 다시 한 번 입력해주세요" />
-    <a><img src="btn_visibility_on_24px.png"></a>
+    <input id="Repassword-Input" class="main-insert-text" type="password" placeholder="비밀번호를 다시 한 번 입력해주세요" />
+    <img id="toggleRePassword" class="password-icon" src="./btn_visibility_on_24px.png">
   </div>
+  <div class="error-message-container"></div> 
   </div>
 
 <div>
-<a class="signup-button">회원가입</a>
+<button class="signup-button">회원가입</button>
 </div>
 
 <div class="easylogin-cotainor">
   <div class="easylogin-content">
 <a class="easylogin-title-text">간편로그인</a>
-<div>
+<div class="easylogin-img-box">
   <a href="https://www.google.com/" target="_brank">
     <img class="easylog-img" src="Component 2.png" >
   </a>
@@ -67,14 +76,23 @@
   <img class="easylog-img" src="Component 3.png">
 </a>
   </div>
-</div>
+ </div>
 </div>
 
 <div class="relogin-cotainor">
 <a>이미 회원이신가요?</a>
 <a href="./login.html">로그인</a>
-    </div>
   </div>
-   </main>
+</form>
+
+<div id="error-modal" class="modal-hidden">
+  <div class="modal-content">
+    <p id="modal-message">사용 중인 이메일입니다.</p>
+    <button id="modal-closeBtn" class="modal-btn">확인</button>
+  </div>
+</div>
+
+</div>
+<script src="signup.js"></script>
  </body>
 </html>

--- a/signup.js
+++ b/signup.js
@@ -1,0 +1,233 @@
+document.addEventListener("DOMContentLoaded", () => {
+  const emailInput = document.querySelector("#email-Input");
+  const passwordInput = document.querySelector("#password-Input");
+  const RepasswordInput = document.querySelector("#Repassword-Input");
+  const togglePassword = document.querySelector("#togglePassword");
+  const toggleRePassword = document.querySelector("#toggleRePassword");
+  const signupBtn = document.querySelector(".signup-button");
+  
+  const USER_DATA = [
+             { email: 'codeit1@codeit.com', password: "codeit101!" },
+             { email: 'codeit2@codeit.com', password: "codeit202!" },
+             { email: 'codeit3@codeit.com', password: "codeit303!" },
+             { email: 'codeit4@codeit.com', password: "codeit404!" },
+             { email: 'codeit5@codeit.com', password: "codeit505!" },
+             { email: 'codeit6@codeit.com', password: "codeit606!" },
+  ]
+  
+  //에러 메세지 생성
+  const createErrorMessage = (input, message) => {
+    removeErrorMessage(input);
+    //Element : 엘리먼트를 추상화한 객체
+    const errorContainer = input.parentElement.nextElementSibling;
+    const errorElement = document.createElement("div");
+    errorElement.className = "error-message";
+    errorElement.textContent = message;
+    errorElement.style.color = "#F74747" ;
+    input.style.borderColor = "#F74747" ;
+    input.classList.add("error");
+    errorContainer.appendChild(errorElement);
+  };
+  
+  const removeErrorMessage = (input) => {
+    input.classList.remove("error");
+    input.style.borderColor = "";
+    const errorContainer = input.parentElement.nextElementSibling;
+    errorContainer.innerHTML = "";
+  };
+  
+  let startLoad = true;
+
+  const validateEmail = () => {
+
+    //emailinput에 들어가는 볼륨 확인
+    //trim() 양끝 공백 제거
+    const emailValue = emailInput.value.trim();
+    const emailxp = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+    if (startLoad) return true;
+
+     if (!emailValue) {
+      createErrorMessage(emailInput, "이메일을 입력해주세요.");
+      return false;
+      //test() : 패턴이 일치하는지 확인하는 불리언 반환 매서드
+    } else if (!emailxp.test(emailValue)){
+      createErrorMessage(emailInput, "잘못된 이메일 형식입니다.");
+      return false;
+    } else {
+      removeErrorMessage(emailInput);
+      return true;
+    }
+  };
+  
+  const validatePassword  = () => {
+    const passwordValue = passwordInput.value.trim();
+
+    if (startLoad) return true;
+
+  
+    if (!passwordValue) {
+      createErrorMessage(passwordInput, "비밀번호를 입력해주세요.");
+      return false;
+    } else if (passwordValue.length < 8) {
+      createErrorMessage(passwordInput, "비밀번호를 8자 이상 입력해주세요.");
+      return false;
+    } else {
+      removeErrorMessage(passwordInput);
+      return true;
+    }
+  };
+
+  const validateRePassword  = () => {
+    const passwordValue = passwordInput.value.trim();
+    const RepasswordValue = RepasswordInput.value.trim();
+
+    if (startLoad) return true;
+
+  
+    if (!RepasswordValue) {
+      createErrorMessage(RepasswordInput, "비밀번호를 입력해주세요.");
+      return false;
+    } else if (RepasswordValue !== passwordValue) {
+      createErrorMessage(RepasswordInput, "비밀번호가 일치하지 않습니다.");
+      return false;
+    } else {
+      removeErrorMessage(RepasswordInput);
+      return true;
+    }
+  };
+  
+
+  // input에 빈 값 or errorm messege 있으면 로그인 버튼 비활성화
+  // input에 유효값이 있다면 로그인 버튼 활성화
+  // 활성화 된 로그인 버튼은 아이템으로 이동
+
+   // 회원가입 버튼 초기 비활성화 설정
+   const disableSignupButton = () => {
+    signupBtn.style.backgroundColor = "var(--inputtextcolor)";
+    signupBtn.style.pointerEvents = "none";
+    signupBtn.style.cursor = "not-allowed";
+    signupBtn.setAttribute("disabled", "true");
+  };
+
+  disableSignupButton();
+  
+  const toggleSignupBtn = () => {
+
+    if(startLoad) return false;
+
+      if (validateEmail() && validatePassword() && validateRePassword()) {
+      signupBtn.style.backgroundColor = "var(--inputfocuscolor)";
+      signupBtn.style.pointerEvents = "";
+      // cursor가 pointer(link)를 나타낸다.
+      signupBtn.style.cursor = "pointer";
+      //Attribute : 모든 속성값을 읽음
+      //disabled : 값이 true면 비활성화, false면 활성화
+      signupBtn.removeAttribute("disabled");
+    } else {
+      disableSignupButton();
+    }
+  };
+  
+  // 눈모양 아이콘 비밀번호 표시/ 숨기기 토글 = 기본상태는 숨김
+  togglePassword.addEventListener("click", () => {
+  if (passwordInput.type === "password"){
+    passwordInput.type = "text";
+  } else {
+    passwordInput.type = "password";
+  }
+  });
+
+  toggleRePassword.addEventListener("click", () => {
+    if (RepasswordInput.type === "password"){
+      RepasswordInput.type = "text";
+    } else {
+      RepasswordInput.type = "password";
+    }
+    });
+  
+  
+  //이벤트 발생
+  emailInput.addEventListener ("blur", () => {
+    startLoad = false;
+    validateEmail();
+    toggleSignupBtn();
+  });
+  emailInput.addEventListener ("input", () => {
+    removeErrorMessage(emailInput);
+    toggleSignupBtn();
+  });
+  
+  
+  passwordInput.addEventListener ("blur", () => {
+    startLoad = false;
+    validatePassword();
+    toggleSignupBtn();
+  });
+
+  passwordInput.addEventListener ("input", () => {
+    removeErrorMessage(passwordInput);
+    toggleSignupBtn();
+  });
+
+
+  RepasswordInput.addEventListener ("blur", () => {
+    startLoad = false;
+    validateRePassword();
+    toggleSignupBtn();
+  });
+  RepasswordInput.addEventListener ("input", () => {
+    removeErrorMessage(RepasswordInput);
+    toggleSignupBtn();
+  });
+  
+
+
+  
+  // 이메일이 데이터베이스에 없거나 이메일은 일치하지만 비밀번호가 틀린경우 "비밀번호가 일치하지 않습니다." alert messege 표시
+  // 오류 메시지 모달을 구현합니다. 모달 내 내용은 alert 메시지와 동일합니다.
+  // (비밀번호가 일치하지 않습니다.)
+  const showModal = (message) => {
+    const modal = document.querySelector("#error-modal");
+    const modalMessage = document.querySelector("#modal-message");
+    modalMessage.textContent = message;
+    modal.classList.add("show");
+  };
+  
+  const closeModal = () => {
+    const modal = document.querySelector("#error-modal");
+    modal.classList.remove("show")
+  };
+  
+
+// 회원가입을 위해 이메일, 닉네임, 비밀번호, 비밀번호 확인을 입력한 뒤, 회원가입 버튼을 클릭하세요. 그 후에는 다음 조건에 따라 회원가입 가능 여부를 alert로 알려주세요.
+// 입력한 이메일이 이미 데이터베이스(USER_DATA)에 존재하는 경우, '사용 중인 이메일입니다'라는 메시지를 alert로 표시합니다.
+// 입력한 이메일이 데이터베이스(USER_DATA)에 없는 경우, 회원가입이 성공적으로 처리되었으므로 로그인 페이지(”/login”)로 이동합니다.
+// 오류 메시지 모달을 구현합니다. 모달 내 내용은 alert 메시지와 동일합니다.
+// (사용 중인 이메일입니다.)
+
+  document.querySelector("#modal-closeBtn").addEventListener("click", closeModal);
+
+  signupBtn.addEventListener("click", (e) => {
+    // 페이지 새로고침 방지
+    e.preventDefault();
+
+    const emailValue = emailInput.value.trim();
+    const passwordValue = passwordInput.value.trim();
+    const RepasswordValue = RepasswordInput.value.trim();
+    //find : 배열에서 특정 조건을 만족하는 요소를 찾아 첫 번째 요소로 반환
+    const user = USER_DATA.find((user) => user.email === emailValue);
+  
+      if (!user){
+        showModal("사용 중인 이메일입니다.");
+      } else if (user.password !== passwordValue && passwordValue !== RepasswordValue) {
+        showModal("사용 중인 이메일입니다.");
+      } else {
+        window.location.href = "./login.html";
+      }
+  
+  });
+  
+  toggleSignupBtn();
+  });
+  


### PR DESCRIPTION
## 배포링크
https://voluble-moxie-3153e3.netlify.app

### 기본

- [o] 로그인 및 회원가입 페이지의 이메일, 비밀번호, 비밀번호 확인 input에 필요한 유효성 검증 함수를 만들고 적용해 주세요.
- [o]  이메일 input에서 focus out 할 때, 값이 없을 경우 input에 빨강색 테두리와 아래에 “이메일을 입력해주세요.” 빨강색 에러 메세지를 보입니다.
- [o] 이메일 input에서 focus out 할 때, 이메일 형식에 맞지 않는 경우 input에 빨강색 테두리와 아래에 “잘못된 이메일 형식입니다” 빨강색 에러 메세지를 보입니다
- [o] 비밀번호 input에서 focus out 할 때, 값이 없을 경우 아래에 “비밀번호를 입력해주세요.” 에러 메세지를 보입니다
- [o] 비밀번호 input에서 focus out 할 때, 값이 8자 미만일 경우 아래에 “비밀번호를 8자 이상 입력해주세요.” 에러 메세지를 보입니다.
- [o] input 에 빈 값이 있거나 에러 메세지가 있으면 ‘로그인’ 버튼은 비활성화 됩니다.
- [o] Input 에 유효한 값을 입력하면 ‘로그인' 버튼이 활성화 됩니다.
- [o] 활성화된 ‘로그인’ 버튼을 누르면 “/items” 로 이동합니다.
- [o] 이메일과 비밀번호를 입력하고 로그인 버튼을 누른 후, 다음 조건을 참조하여 로그인 성공 여부를 alert 메시지로 출력합니다.
- [o] 만약 입력한 이메일이 데이터베이스(USER_DATA)에 없거나, 이메일은 일치하지만 비밀번호가 틀린 경우, '비밀번호가 일치하지 않습니다.'라는 메시지를 alert로 표시합니다.
- [o] 만약 입력한 이메일이 데이터베이스에 존재하고, 비밀번호도 일치할 경우, “/items”로 이동합니다.
- [o] 회원가입을 위해 이메일, 닉네임, 비밀번호, 비밀번호 확인을 입력한 뒤, 회원가입 버튼을 클릭하세요. 그 후에는 다음 조건에 따라 회원가입 가능 여부를 alert로 알려주세요.
- [o] 입력한 이메일이 이미 데이터베이스(USER_DATA)에 존재하는 경우, '사용 중인 이메일입니다'라는 메시지를 alert로 표시합니다.
- [o] 입력한 이메일이 데이터베이스(USER_DATA)에 없는 경우, 회원가입이 성공적으로 처리되었으므로 로그인 페이지(”/login”)로 이동합니다.

### 심화

- [o] 페이스북, 카카오톡, 디스코드, 트위터 등 SNS에서 판다마켓 랜딩 페이지(“/”) 공유 시 미리보기를 볼 수 있도록 랜딩 페이지 메타 태그를 설정합니다. 주소와 이미지는 자유롭게 설정하세요.
- [o] 미리보기에서 제목은 “판다마켓”, 설명은 “일상에서 모든 물건을 거래해보세요”로 설정합니다.
- [o] 로그인, 회원가입 페이지에 공통으로 사용하는 로직이 있다면, 반복하지 않고 공통된 로직을 모듈로 분리해 사용해 주세요.
- [o] 브라우저에 현재 보이는 화면의 영역(viewport) 너비를 기준으로 분기되는 반응형 디자인을 적용합니다.
- [o] Tablet 사이즈로 작아질 때 최소 좌우 여백이 “판다마켓” 로고의 왼쪽에 여백 24px, “로그인” 버튼 오른쪽 여백 24px을 유지할 수 있도록 “판다마켓” 로고와 “로그인" 버튼의 간격이 가까워집니다.
- [o]  Mobile 사이즈로 작아질 때 최소 좌우 여백이 “판다마켓” 로고의 왼쪽에 여백 16px, “로그인” 버튼 오른쪽 여백 16px을 유지할 수 있도록 “판다마켓” 로고와 “로그인" 버튼의 간격이 가까워집니다.
- [o] PC, Tablet 사이즈의 이미지 크기는 고정값을 사용합니다.
- [o] Mobile 사이즈의 이미지는 좌우 여백 32px을 제외하고 이미지 영역이 꽉 차게 구현합니다. (이때 가로가 커지는 비율에 맞춰 세로도 커져야 합니다.)
- [o] Mobile 사이즈 너비가 커지면, “Privacy Policy”, “FAQ”, “codeit-2023”이 있는 영역과 SNS 아이콘들이 있는 영역의 사이 간격이 커집니다.
- [o]  Tablet 사이즈에서 내부 디자인은 PC사이즈와 동일합니다.
- [o] Mobile 사이즈에서 좌우 여백 16px 제외하고 내부 요소들이 너비를 모두 차지합니다.
- [o] Mobile 사이즈에서 내부 요소들의 너비는 기기의 너비가 커지는 만큼 커지지만 400px을 넘지 않습니다.
- [o] 오류 메시지 모달을 구현합니다. 모달 내 내용은 alert 메시지와 동일합니다.
- [o] 비밀번호 및 비밀번호 확인 입력란에 눈 모양 아이콘 클릭 시 비밀번호 표시/숨기기 토글이 가능합니다. 기본 상태는 비밀번호 숨김으로 설정합니다.

## 주요 변경사항

- focus가 아닌 input상황일 때에도 input의 유효성을 검토하여 실시간으로 에러 메시지 나오도록 기능 추가함.
- 페이지 사이즈에 따라  화면의 영역(viewport) 너비를 기준으로 분기되는 반응형 디자인을 적용

## 스크린샷
![voluble-moxie-3153e3 netlify app_ (1)](https://github.com/user-attachments/assets/5a48b219-a715-4ae4-b89f-075d18f0161c)

## 멘토에게


- 셀프 코드 리뷰를 통해 질문 이어가겠습니다.
