### PR TITLE
[최유리] sprint3

### DIFF
--- a/event.js
+++ b/event.js
@@ -1,0 +1,121 @@
+
+
+
+//JS 
+const INPUTDATA = document.querySelector('#UserEmail');
+const INPUTDATATEXT = document.querySelector('#EmailE');
+const INPUTPW = document.querySelector('#PassWord');
+const INPUTPWTEXT = document.querySelector('#PassWordE');
+const LOGBUTTON = document.querySelector('#Loginbn');
+
+
+
+const USER_DATA = [
+    { email: 'codeit1@codeit.com', password: "codeit101!" },
+    { email: 'codeit2@codeit.com', password: "codeit202!" },
+    { email: 'codeit3@codeit.com', password: "codeit303!" },
+    { email: 'codeit4@codeit.com', password: "codeit404!" },
+    { email: 'codeit5@codeit.com', password: "codeit505!" },
+    { email: 'codeit6@codeit.com', password: "codeit606!" },
+]
+
+// 인풋박스 포커스 로그인화면
+
+let toggleEmail = 0;
+let togglePwd = 0;
+
+// 버튼 활성화 여부를 결정하는 함수
+function judgeBtn() {
+    if (toggleEmail === 1 && togglePwd === 1) {
+        LOGBUTTON.classList.add('blueLoginButton');
+        LOGBUTTON.addEventListener('click',() => {
+
+            let judgeEmail = false;
+            let judgePwd = false;
+            for (let i = 0; i < USER_DATA.length; i++){
+                if (USER_DATA[i].email === INPUTDATA.value){
+                    judgeEmail = true;
+                    break;
+                }}
+            for (let i = 0; i < USER_DATA.length; i++){
+                if (USER_DATA[i].password === INPUTPW.value){
+                    judgePwd = true;
+                    break;
+                }}
+
+            if (judgeEmail === false && judgePwd === true){
+                window.alert("이메일이 일치하지 않습니다.");
+                
+            } else if (judgeEmail === true && judgePwd === false) {
+                window.alert("비밀번호가 일치하지 않습니다.");
+                
+            } else if(judgeEmail === false && judgePwd === false) {
+                window.alert("회원정보를 확인해주세요.");
+            
+            } else {
+                // window.location.href = "/items.html";
+                window.open("/items.html");
+            }
+        });
+
+    } else {
+        LOGBUTTON.classList.remove('blueLoginButton');
+    }
+};
+
+
+const InputEmail=(event)=>{
+    const emailpattern = /^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/;
+    return emailpattern.test(event);
+};
+
+
+INPUTDATA.addEventListener('focusout',function(event) {
+        if (event.target.value === ''){
+            event.target.classList.add('Error')
+            INPUTDATATEXT.textContent = '이메일을 입력해주세요.';
+            toggleEmail = 0;
+            judgeBtn();
+
+        } else if (!InputEmail(event.target.value)){
+            event.target.classList.add('Error')
+            INPUTDATATEXT.textContent = '잘못된 이메일 형식입니다.';
+            toggleEmail = 0;
+            judgeBtn();
+
+        } else {
+            event.target.classList.remove('Error')
+            INPUTDATATEXT.textContent = '';
+            toggleEmail = 1;
+            judgeBtn();
+        }
+                
+});
+
+
+INPUTPW.addEventListener('focusout',function(event) {
+        if (event.target.value === ''){
+            event.target.classList.add('Error')
+            INPUTPWTEXT.textContent = '비밀번호를 입력해주세요.';
+            togglePwd = 0;
+            judgeBtn();
+
+        } else if (event.target.value.length < 8 ) {
+            event.target.classList.add('Error')
+            INPUTPWTEXT.textContent = '비밀번호를 8자 이상 입력해주세요.';
+            togglePwd = 0;
+            judgeBtn();
+            
+
+        } else {
+            event.target.classList.remove('Error')
+            INPUTPWTEXT.textContent = '';
+            togglePwd = 1;
+            judgeBtn();
+        }
+});
+
+
+
+
+

--- a/event2.js
+++ b/event2.js
@@ -1,0 +1,130 @@
+
+
+const NEWINPUTDATA = document.querySelector('#UserEmailNew');
+const NEWINPUTDATATEXT = document.querySelector('#UserEmailNewE');
+const NEWINPUTNAME = document.querySelector('#NicknameNew');
+const NEWINPUTPW = document.querySelector('#PassWordNew');
+const NEWINPUTPWTEXT = document.querySelector('#PassWordNewE');
+const NEWINPUTPWE = document.querySelector('#PassWordreNew');
+const NEWINPUTPWETEXT = document.querySelector('#PassWordreNewE');
+const NEWLOGBUTTON = document.querySelector('#LoginbnNew');
+
+
+const USER_DATA = [
+    { email: 'codeit1@codeit.com', password: "codeit101!" },
+    { email: 'codeit2@codeit.com', password: "codeit202!" },
+    { email: 'codeit3@codeit.com', password: "codeit303!" },
+    { email: 'codeit4@codeit.com', password: "codeit404!" },
+    { email: 'codeit5@codeit.com', password: "codeit505!" },
+    { email: 'codeit6@codeit.com', password: "codeit606!" },
+]
+
+
+
+// 인풋박스 포커스 회원가입화면
+const NewInputEmail=(event)=>{
+    const Newemailpattern = /^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/;
+    return Newemailpattern.test(event);
+};
+
+let NewtoggleEmail = 0;
+let NewtogglePwd = 0;
+let NewtogglePwde = 0;
+
+NEWINPUTDATA.addEventListener('focusout',function(event) {
+        if (event.target.value === ''){
+            event.target.classList.add('Error')
+            NEWINPUTDATATEXT.textContent = '이메일을 입력해주세요.';
+            NewtoggleEmail = 0;
+            NewjudgeBtn();
+
+        } else if (!NewInputEmail(event.target.value)){
+            event.target.classList.add('Error')
+            NEWINPUTDATATEXT.textContent = '잘못된 이메일 형식입니다.';
+            NewtoggleEmail = 0;
+            NewjudgeBtn();
+
+        } else {
+            event.target.classList.remove('Error')
+            NEWINPUTDATATEXT.textContent = '';
+            NewtoggleEmail = 1;
+            NewjudgeBtn();
+        }
+                
+});
+
+
+
+NEWINPUTPW.addEventListener('focusout',function(event) {
+        if (event.target.value === ''){
+            event.target.classList.add('Error')
+            NEWINPUTPWTEXT.textContent = '비밀번호를 입력해주세요.';
+            NewtogglePwd = 0;
+            NewjudgeBtn();
+
+        } else if (event.target.value.length < 8 ) {
+            event.target.classList.add('Error')
+            NEWINPUTPWTEXT.textContent = '비밀번호를 8자 이상 입력해주세요.';
+            NewtogglePwd = 0;
+            NewjudgeBtn();
+            
+
+        } else {
+            event.target.classList.remove('Error')
+            NEWINPUTPWTEXT.textContent = '';
+            NewtogglePwd = 1;
+            NewjudgeBtn();
+        }
+});
+
+
+
+NEWINPUTPWE.addEventListener('focusout',function(event) {
+    if (event.target.value === ''){
+        event.target.classList.add('Error')
+        NEWINPUTPWETEXT.textContent = '비밀번호를 입력해주세요.';
+        NewtogglePwde = 0;
+        NewjudgeBtn();
+
+    } else if (event.target.value !== NEWINPUTPW.value ) {
+        event.target.classList.add('Error')
+        NEWINPUTPWETEXT.textContent = '비밀번호가 일치하지 않습니다.';
+        NewtogglePwde = 0;
+        NewjudgeBtn();
+        
+    } else {
+        event.target.classList.remove('Error')
+        NEWINPUTPWETEXT.textContent = '';
+        NewtogglePwde = 1;
+        NewjudgeBtn();
+    }
+});
+
+
+// 회원가입버튼 활성화 여부를 결정하는 함수
+function NewjudgeBtn() {
+    if (NewtoggleEmail === 1 && NewtogglePwd === 1 && NewtogglePwde === 1) {
+        NEWLOGBUTTON.classList.add('blueLoginButton');
+        NEWLOGBUTTON.addEventListener('click',() => {
+
+            let NewjudgeEmail = false;
+
+            for (let i = 0; i < USER_DATA.length; i++){
+                if (USER_DATA[i].email === NEWINPUTDATA.value){
+                    NewjudgeEmail = true;
+                    break;
+                }}
+
+            if (NewjudgeEmail === true) {
+                window.alert("사용 중인 이메일입니다.");
+
+            } else {
+                // window.location.href = "/items.html";
+                window.open("login.html");
+            }
+        });
+
+    } else {
+        LOGBUTTON.classList.remove('blueLoginButton');
+    }
+};

--- a/login.html
+++ b/login.html
@@ -23,14 +23,17 @@
             <div class="FormArray">
                 <label for="UserEmail">이메일</label>
                 <input type="text" id="UserEmail" placeholder="이메일을 입력해주세요">
+                <div class="ErrorMessage" id="EmailE"></div>
             </div>
 
             <div class="FormArray">
                 <label for="PassWord">비밀번호</label>
                 <input class="PWIcon" type="password" id="PassWord" placeholder="비밀번호를 입력해주세요">
+                <div class="ErrorMessage" id="PassWordE"></div>
             </div>
 
-            <input class="LoginButton" type="submit" value="로그인">
+        
+            <input class="LoginButton" id="Loginbn" type="submit" value="로그인">
 
             <div class="EasyLogin">
                 <div class="EasyLoginArray">
@@ -55,6 +58,9 @@
             </div>
         </form>
     </div>
+
+
+    <script src="event.js"></script>
 
 </body>
 </html>

--- a/signup.html
+++ b/signup.html
@@ -20,25 +20,28 @@
         <form>
             <div class="FormArray">
                 <label for="UserEmail">이메일</label>
-                <input type="text" id="UserEmail" placeholder="이메일을 입력해주세요">
+                <input type="text" id="UserEmailNew" placeholder="이메일을 입력해주세요">
+                <div class="ErrorMessage" id="UserEmailNewE"></div>
             </div>
 
             <div class="FormArray">
                 <label for="Nickname">닉네임</label>
-                <input type="text" id="Nickname" placeholder="닉네임을 입력해주세요">
+                <input type="text" id="NicknameNew" placeholder="닉네임을 입력해주세요">
             </div>
 
             <div class="FormArray">
                 <label for="PassWord">비밀번호</label>
-                <input class="PWIcon" type="password" id="PassWord" placeholder="비밀번호를 입력해주세요">
+                <input class="PWIcon" type="password" id="PassWordNew" placeholder="비밀번호를 입력해주세요">
+                <div class="ErrorMessage" id="PassWordNewE"></div>
             </div>
 
             <div class="FormArray">
                 <label for="PassWordre">비밀번호 확인</label>
-                <input class="PWIcon" type="password" id="PassWordre" placeholder="비밀번호를 다시 한 번 입력해주세요">
+                <input class="PWIcon" type="password" id="PassWordreNew" placeholder="비밀번호를 다시 한 번 입력해주세요">
+                <div class="ErrorMessage" id="PassWordreNewE"></div>
             </div>
 
-            <input class="LoginButton" type="submit" value="회원가입">
+            <input class="LoginButton" id="LoginbnNew" type="submit" value="회원가입">
 
             <div class="EasyLogin">
                 <div class="EasyLoginArray">
@@ -63,6 +66,8 @@
             </div>
         </form>
     </div>
+
+    <script src="event2.js"></script>
 
 </body>
 </html>

--- a/style.css
+++ b/style.css
@@ -213,7 +213,6 @@ label{
 input{
   max-width: 640px;
   height: 56px;
-  margin-bottom: 24px;
   border-radius: 12px;
   border: none;
   background-color: #f3f4f6;
@@ -256,8 +255,7 @@ input::placeholder{
     background-color: #9ca3af;
     border: none;
     border-radius: 40px;
-    margin-bottom: 24px;
-  
+    margin:24px 0px;
     color: #f3f4f6;
     font-size: 20px;
   }
@@ -325,3 +323,25 @@ input::placeholder{
 
     
     a {color : #3692ff; margin-left: 4px;}
+
+
+
+
+  /* jS */
+  .Error {
+    border:1px solid red;
+  }
+
+  .ErrorMessage {
+    color: red;
+    font-size: 15px;
+    display: flex;
+    flex-direction: column;
+    justify-content:flex-start;
+    padding : 8px 24px;
+  }
+
+
+  .blueLoginButton {
+    background-color:#3692FF
+  }


### PR DESCRIPTION
## 기본
 로그인 및 회원가입 페이지의 이메일, 비밀번호, 비밀번호 확인 input에 필요한 유효성 검증 함수를 만들고 적용해 주세요.
 - [x] 이메일 input에서 focus out 할 때, 값이 없을 경우 input에 빨강색 테두리와 아래에 “이메일을 입력해주세요.” 빨강색 에러 메세지를 보입니다.
 - [x] 이메일 input에서 focus out 할 때, 이메일 형식에 맞지 않는 경우 input에 빨강색 테두리와 아래에 “잘못된 이메일 형식입니다” 빨강색 에러 메세지를 보입니다.
 - [x] 비밀번호 input에서 focus out 할 때, 값이 없을 경우 아래에 “비밀번호를 입력해주세요.” 에러 메세지를 보입니다
 - [x] 비밀번호 input에서 focus out 할 때, 값이 8자 미만일 경우 아래에 “비밀번호를 8자 이상 입력해주세요.” 에러 메세지를 보입니다.
 - [x] input 에 빈 값이 있거나 에러 메세지가 있으면 ‘로그인’ 버튼은 비활성화 됩니다.
 - [x] Input 에 유효한 값을 입력하면 ‘로그인' 버튼이 활성화 됩니다.
 - [x] 활성화된 ‘로그인’ 버튼을 누르면 “/items” 로 이동합니다
 - [x] 이메일과 비밀번호를 입력하고 로그인 버튼을 누른 후, 다음 조건을 참조하여 로그인 성공 여부를 alert 메시지로 출력합니다.
 - [x] 만약 입력한 이메일이 데이터베이스(USER_DATA)에 없거나, 이메일은 일치하지만 비밀번호가 틀린 경우, '비밀번호가 일치하지 않습니다.'라는 메시지를 alert로 표시합니다
 - [x] 만약 입력한 이메일이 데이터베이스에 존재하고, 비밀번호도 일치할 경우, “/items”로 이동합니다.
 - [x] 회원가입을 위해 이메일, 닉네임, 비밀번호, 비밀번호 확인을 입력한 뒤, 회원가입 버튼을 클릭하세요. 그 후에는 다음 조건에 따라 회원가입 가능 여부를 alert로 알려주세요.
입력한 이메일이 이미 데이터베이스(USER_DATA)에 존재하는 경우, '사용 중인 이메일입니다'라는 메시지를 alert로 표시합니다.
 - [x] 입력한 이메일이 데이터베이스(USER_DATA)에 없는 경우, 회원가입이 성공적으로 처리되었으므로 로그인 페이지(”/login”)로 이동합니다.
## 심화
- [ ] 페이스북, 카카오톡, 디스코드, 트위터 등 SNS에서 판다마켓 랜딩 페이지(“/”) 공유 시 미리보기를 볼 수 있도록 랜딩 페이지 메타 태그를 설정합니다.
- [ ] 미리보기에서 제목은 “판다마켓”, 설명은 “일상에서 모든 물건을 거래해보세요”로 설정합니다.
- [ ] 주소와 이미지는 자유롭게 설정하세요.
- [ ] 로그인, 회원가입 페이지에 공통으로 사용하는 로직이 있다면, 반복하지 않고 공통된 로직을 모듈로 분리해 사용해 주세요.
- [ ] 랜딩 페이지


## 주요 변경사항

## 스크린샷

## 멘토에게
- 완성에 목표를 두어가지고 이전에 주신 내용 반영이 안되었습니다 ㅠㅠ
- 셀프 코드 리뷰를 통해 질문 이어가겠습니다.

##  배포 URL
-https://whimsical-granita-255f33.netlify.app/

